### PR TITLE
Added folder structure for remote index build service

### DIFF
--- a/remote-vector-index-builder/__init__.py
+++ b/remote-vector-index-builder/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/remote-vector-index-builder/core/__init__.py
+++ b/remote-vector-index-builder/core/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/remote-vector-index-builder/core/main.py
+++ b/remote-vector-index-builder/core/main.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/remote-vector-index-builder/testing_api/__init__.py
+++ b/remote-vector-index-builder/testing_api/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/remote-vector-index-builder/testing_api/app.py
+++ b/remote-vector-index-builder/testing_api/app.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/test_remote-vector-index-builder/__init__.py
+++ b/test_remote-vector-index-builder/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.


### PR DESCRIPTION
### Description
Separating the code into `core` for the object store and faiss client implementations, and `testing_api` for the API skeleton. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).