### PR TITLE
Added checksum support to s3 operations. 

### DIFF
--- a/remote_vector_index_builder/core/common/models/index_build_parameters.py
+++ b/remote_vector_index_builder/core/common/models/index_build_parameters.py
@@ -18,16 +18,10 @@ class DataType(str, Enum):
     """Supported data types for vector values.
 
     Attributes:
-        FLOAT32: 32-bit floating point values
-        FLOAT16: 16-bit floating point values
-        BYTE: 8-bit integer values
-        BINARY: Binary data format
+        FLOAT: 32-bit floating point values
     """
 
-    FLOAT32 = "fp32"
-    FLOAT16 = "fp16"
-    BYTE = "byte"
-    BINARY = "binary"
+    FLOAT = "float"
 
 
 class SpaceType(str, Enum):
@@ -35,19 +29,11 @@ class SpaceType(str, Enum):
 
     Attributes:
         L2: Euclidean distance
-        COSINESIMIL: Cosine similarity
-        L1: Manhattan distance
-        LINF: Chebyshev distance
         INNERPRODUCT: Dot product similarity
-        HAMMING: Hamming distance for binary vectors
     """
 
     L2 = "l2"
-    COSINESIMIL = "cosinesimil"
-    L1 = "l1"
-    LINF = "linf"
     INNERPRODUCT = "innerproduct"
-    HAMMING = "hamming"
 
 
 class Algorithm(str, Enum):
@@ -145,7 +131,7 @@ class IndexBuildParameters(BaseModel):
     tenant_id: str = ""
     dimension: int = Field(gt=0)
     doc_count: int = Field(gt=0)
-    data_type: DataType = DataType.FLOAT32
+    data_type: DataType = DataType.FLOAT
     engine: Engine = Engine.FAISS
     index_parameters: IndexParameters = Field(default_factory=IndexParameters)
     model_config = ConfigDict(extra="forbid")

--- a/remote_vector_index_builder/core/common/models/vectors_dataset.py
+++ b/remote_vector_index_builder/core/common/models/vectors_dataset.py
@@ -47,14 +47,8 @@ class VectorsDataset:
         Raises:
             UnsupportedVectorsDataTypeError: If the provided data type is not supported.
         """
-        if dtype == DataType.FLOAT32:
+        if dtype == DataType.FLOAT:
             return "<f4"
-        elif dtype == DataType.FLOAT16:
-            return "<f2"
-        elif dtype == DataType.BYTE:
-            return "<i1"
-        elif dtype == DataType.BINARY:
-            return "<i1"
         else:
             raise UnsupportedVectorsDataTypeError(f"Unsupported data type: {dtype}")
 

--- a/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
+++ b/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
@@ -47,6 +47,10 @@ class S3ObjectStore(ObjectStore):
     Attributes:
         DEFAULT_TRANSFER_CONFIG (dict): Default configuration for S3 file transfers,
             including chunk sizes, concurrency, and retry settings
+        DEFAULT_DOWNLOAD_ARGS (dict): Default boto3 ALLOWED_DOWNLOAD_ARGS values.
+            Includes encryption and checksum settings.
+        DEFAULT_UPLOAD_ARGS (dict): Default boto3 ALLOWED_UPLOAD_ARGS values.
+            Includes encryption and checksum settings
 
     Args:
         index_build_params (IndexBuildParameters): Parameters for the index building process
@@ -56,7 +60,7 @@ class S3ObjectStore(ObjectStore):
     DEFAULT_TRANSFER_CONFIG = {
         "multipart_chunksize": 10 * 1024 * 1024,  # 10MB
         "max_concurrency": (os.cpu_count() or 2)
-        // 2,  # os.cpu_count can None, according to mypy. If it is none, then default to 1 thread
+        // 2,  # os.cpu_count can be None, according to mypy. If it is none, then default to 1 thread
         "multipart_threshold": 10 * 1024 * 1024,  # 10MB
         "use_threads": True,
         "max_bandwidth": None,
@@ -64,6 +68,50 @@ class S3ObjectStore(ObjectStore):
         "num_download_attempts": 5,
         "max_io_queue": 100,
         "preferred_transfer_client": "auto",
+    }
+
+    DEFAULT_DOWNLOAD_ARGS = {
+        "ChecksumMode": "ENABLED",
+        "VersionId": None,
+        "SSECustomerAlgorithm": None,
+        "SSECustomerKey": None,
+        "SSECustomerKeyMD5": None,
+        "RequestPayer": None,
+        "ExpectedBucketOwner": None,
+    }
+
+    DEFAULT_UPLOAD_ARGS = {
+        "ACL": None,
+        "CacheControl": None,
+        "ChecksumAlgorithm": "SHA256",
+        "ContentDisposition": None,
+        "ContentEncoding": None,
+        "ContentLanguage": None,
+        "ContentType": None,
+        "ExpectedBucketOwner": None,
+        "Expires": None,
+        "GrantFullControl": None,
+        "GrantRead": None,
+        "GrantReadACP": None,
+        "GrantWriteACP": None,
+        "Metadata": None,
+        "RequestPayer": None,
+        "ServerSideEncryption": None,
+        "StorageClass": None,
+        "SSECustomerAlgorithm": None,
+        "SSECustomerKey": None,
+        "SSECustomerKeyMD5": None,
+        "SSEKMSKeyId": None,
+        "SSEKMSEncryptionContext": None,
+        "Tagging": None,
+        "WebsiteRedirectLocation": None,
+        "ChecksumType": None,
+        "MpuObjectSize": None,
+        "ChecksumCRC32": None,
+        "ChecksumCRC32C": None,
+        "ChecksumCRC64NVME": None,
+        "ChecksumSHA1": None,
+        "ChecksumSHA256": None,
     }
 
     def __init__(
@@ -90,7 +138,26 @@ class S3ObjectStore(ObjectStore):
 
         transfer_config = object_store_config.get("transfer_config", {})
         # Create transfer config with validated parameters
-        self.transfer_config = self._create_transfer_config(transfer_config)
+        # This is passed as the 'Config' parameter to the boto3 download and upload API calls
+        self.transfer_config = TransferConfig(
+            **S3ObjectStore._create_custom_config(
+                transfer_config, self.DEFAULT_TRANSFER_CONFIG
+            )
+        )
+
+        download_args = object_store_config.get("download_args", {})
+        # Create download args with validated parameters
+        # This is passed as the 'ExtraArgs' parameter to the boto3 download API call
+        self.download_args = S3ObjectStore._create_custom_config(
+            download_args, self.DEFAULT_DOWNLOAD_ARGS
+        )
+
+        upload_args = object_store_config.get("upload_args", {})
+        # Create upload args with validated parameters
+        # This is passed as the 'ExtraArgs' parameter to the boto3 upload API call
+        self.upload_args = S3ObjectStore._create_custom_config(
+            upload_args, self.DEFAULT_UPLOAD_ARGS
+        )
 
         self.debug = object_store_config.get("debug", False)
 
@@ -101,33 +168,37 @@ class S3ObjectStore(ObjectStore):
             self._write_progress = 0
             self._write_progress_lock = threading.Lock()
 
-    def _create_transfer_config(self, custom_config: Dict[str, Any]) -> TransferConfig:
+    @staticmethod
+    def _create_custom_config(
+        custom_config: Dict[str, Any], default_config: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
-        Creates a TransferConfig with custom parameters while maintaining defaults
-        for unspecified values.
+        Merges custom boto3 configuration parameters with default values, ensuring any
+        unspecified parameters retain their default settings.
 
         Args:
-            custom_config: Dictionary of custom transfer configuration parameters
+            custom_config (dict): User-provided configuration parameters to override defaults
+            default_config (dict): Base configuration parameters that will be used if not
+                specified in custom_config
 
         Returns:
-            TransferConfig: Configured transfer configuration object
+            dict: A merged configuration dictionary suitable for boto3 TransferConfig
+                or ExtraArgs parameters, where custom values take precedence over defaults
         """
-        # Start with default values
-        config_params = self.DEFAULT_TRANSFER_CONFIG.copy()
 
+        # Start with default values
+        config_params = default_config.copy()
         # Update with custom values, only if they are valid parameters
         for key, value in custom_config.items():
-            if key in self.DEFAULT_TRANSFER_CONFIG:
+            if key in default_config:
                 config_params[key] = value
             else:
-                logger.info(
-                    f"Warning: Ignoring invalid transfer config parameter: {key}"
-                )
+                logger.info(f"Warning: Ignoring invalid config parameter: {key}")
 
         # Remove None values to let boto3 use its internal defaults
         config_params = {k: v for k, v in config_params.items() if v is not None}
 
-        return TransferConfig(**config_params)
+        return config_params
 
     def read_blob(self, remote_store_path: str, bytes_buffer: BytesIO) -> None:
         """
@@ -173,6 +244,7 @@ class S3ObjectStore(ObjectStore):
                 bytes_buffer,
                 Config=self.transfer_config,
                 Callback=callback_func,
+                ExtraArgs=self.download_args,
             )
             return
         except ClientError as e:
@@ -219,6 +291,7 @@ class S3ObjectStore(ObjectStore):
                 remote_store_path,
                 Config=self.transfer_config,
                 Callback=callback_func,
+                ExtraArgs=self.upload_args,
             )
             return
         except ClientError as e:

--- a/test_remote_vector_index_builder/test_core/common/models/test_vectors_dataset.py
+++ b/test_remote_vector_index_builder/test_core/common/models/test_vectors_dataset.py
@@ -47,10 +47,7 @@ def test_free_vectors_space(vectors_dataset):
 @pytest.mark.parametrize(
     "dtype, expected",
     [
-        (DataType.FLOAT32, "<f4"),
-        (DataType.FLOAT16, "<f2"),
-        (DataType.BYTE, "<i1"),
-        (DataType.BINARY, "<i1"),
+        (DataType.FLOAT, "<f4"),
     ],
 )
 def test_get_numpy_dtype_valid(dtype, expected):
@@ -73,19 +70,13 @@ def test_check_dimensions_invalid():
         VectorsDataset.check_dimensions(vectors, 10)
 
 
-@pytest.mark.parametrize(
-    "vector_dtype", [DataType.FLOAT32, DataType.FLOAT16, DataType.BYTE, DataType.BINARY]
-)
+@pytest.mark.parametrize("vector_dtype", [DataType.FLOAT])
 def test_parse_valid_data(vector_dtype):
     # Prepare test data
     dimension = 3
     doc_count = 2
 
     arr = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
-    if vector_dtype == DataType.BYTE:
-        arr = [[1, 2, 3], [4, 5, 6]]
-    elif vector_dtype == DataType.BINARY:
-        arr = [[0, 0, 0], [1, 1, 1]]
 
     test_vectors = np.array(arr, dtype=VectorsDataset.get_numpy_dtype(vector_dtype))
     test_doc_ids = np.array([1, 2], dtype="<i4")
@@ -125,7 +116,7 @@ def test_parse_invalid_doc_count():
             doc_ids=doc_ids,
             dimension=2,
             doc_count=2,
-            vector_dtype=DataType.FLOAT32,
+            vector_dtype=DataType.FLOAT,
         )
         dataset.free_vectors_space()
         vectors.close()
@@ -141,7 +132,7 @@ def test_parse_invalid_vector_dimensions():
             doc_ids=doc_ids,
             dimension=3,  # Expecting 6 values (2*3), but only provided 4
             doc_count=2,
-            vector_dtype=DataType.FLOAT32,
+            vector_dtype=DataType.FLOAT,
         )
         dataset.free_vectors_space()
         vectors.close()
@@ -160,7 +151,7 @@ def test_parse_invalid_data():
                 doc_ids=doc_ids,
                 dimension=3,
                 doc_count=2,
-                vector_dtype=DataType.FLOAT32,
+                vector_dtype=DataType.FLOAT,
             )
             dataset.free_vectors_space()
             vectors.close()

--- a/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
+++ b/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
@@ -102,17 +102,32 @@ def test_s3_object_store_initialization_debug_config(index_build_params):
             assert store.debug
 
 
-def test_create_transfer_config(s3_object_store):
+def test_create_custom_config(index_build_params):
     custom_config = {
-        "multipart_chunksize": 20 * 1024 * 1024,
-        "max_concurrency": 8,
-        "invalid_param": "value",  # Should be ignored
+        "retries": 3,
+        "region": "us-west-2",
+        "debug": False,
+        "transfer_config": {
+            "multipart_chunksize": 20 * 1024 * 1024,
+            "max_concurrency": 8,
+            "invalid_param": "value",
+        },
+        "download_args": {"ChecksumMode": "DISABLED", "invalid_param": "value"},
+        "upload_args": {"ChecksumAlgorithm": "SHA1", "invalid_param": "value"},
     }
 
-    config = s3_object_store._create_transfer_config(custom_config)
-    assert config.multipart_chunksize == 20 * 1024 * 1024
-    assert config.max_concurrency == 8
-    assert "invalid_param" not in config.__dict__
+    with patch("core.object_store.s3.s3_object_store.get_boto3_client"):
+        store = S3ObjectStore(index_build_params, custom_config)
+        assert store.max_retries == 3
+        assert store.region == "us-west-2"
+        assert not store.debug
+        assert store.transfer_config.multipart_chunksize == 20 * 1024 * 1024
+        assert store.transfer_config.max_concurrency == 8
+        assert "invalid_param" not in store.transfer_config.__dict__
+        assert store.download_args["ChecksumMode"] == "DISABLED"
+        assert store.upload_args["ChecksumAlgorithm"] == "SHA1"
+        assert "invalid_param" not in store.download_args
+        assert "invalid_param" not in store.upload_args
 
 
 def test_read_blob_success(index_build_params, object_store_config, bytes_buffer):
@@ -127,6 +142,7 @@ def test_read_blob_success(index_build_params, object_store_config, bytes_buffer
             bytes_buffer,
             Config=store.transfer_config,
             Callback=None,
+            ExtraArgs=store.download_args,
         )
 
 
@@ -173,6 +189,7 @@ def test_write_blob_success(index_build_params, object_store_config):
             "remote/path",
             Config=store.transfer_config,
             Callback=None,
+            ExtraArgs=store.upload_args,
         )
 
 

--- a/test_remote_vector_index_builder/test_core/test_tasks.py
+++ b/test_remote_vector_index_builder/test_core/test_tasks.py
@@ -45,7 +45,7 @@ def index_build_params():
         doc_id_path="doc.knndid",
         dimension=128,
         doc_count=1000,
-        data_type="fp32",
+        data_type="float",
         repository_type="s3",
         container_name="test-bucket",
     )


### PR DESCRIPTION
### Description
Adding support for checksums on s3 file download and upload operations. Defaulting to SHA256 for uploads. 
Also, modified the enums for `data_type` and `space_type` in the `IndexBuildParameters` to match what's here: https://github.com/opensearch-project/remote-vector-index-builder/blob/main/API.md

### Issues Resolved
Closes https://github.com/opensearch-project/remote-vector-index-builder/issues/12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).