### PR TITLE
Added dockerfile for core index build library

### DIFF
--- a/remote_vector_index_builder/Dockerfile
+++ b/remote_vector_index_builder/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir --upgrade -r /remote_vector_index_builder/core/re
 
 COPY . /remote_vector_index_builder
 
-ENV PYTHONPATH='${PYTHONPATH}:/remote_vector_index_builder'
+ENV PYTHONPATH='${PYTHONPATH}:/tmp/faiss/build/faiss/python:/remote_vector_index_builder'
 
 RUN ["python", "test_imports.py"]
 CMD ["python", "core/main.py"]

--- a/remote_vector_index_builder/Dockerfile
+++ b/remote_vector_index_builder/Dockerfile
@@ -1,11 +1,14 @@
 FROM rchitale7/remote-index-build-service:faiss-base
 
-WORKDIR /app
+WORKDIR /remote_vector_index_builder
 
-COPY core/requirements.txt /app/requirements.txt
+COPY core/requirements.txt /remote_vector_index_builder/core/requirements.txt
 
-RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /remote_vector_index_builder/core/requirements.txt
 
-COPY . /app
+COPY . /remote_vector_index_builder
 
-CMD ["python", "test_imports.py"]
+ENV PYTHONPATH='${PYTHONPATH}:/remote_vector_index_builder'
+
+RUN ["python", "test_imports.py"]
+CMD ["python", "core/main.py"]

--- a/remote_vector_index_builder/Dockerfile
+++ b/remote_vector_index_builder/Dockerfile
@@ -1,0 +1,11 @@
+FROM rchitale7/remote-index-build-service:faiss-base
+
+WORKDIR /app
+
+COPY core/requirements.txt /app/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+
+COPY . /app
+
+CMD ["python", "test_imports.py"]

--- a/remote_vector_index_builder/Dockerfile
+++ b/remote_vector_index_builder/Dockerfile
@@ -9,6 +9,5 @@ RUN pip install --no-cache-dir --upgrade -r /remote_vector_index_builder/core/re
 COPY . /remote_vector_index_builder
 
 ENV PYTHONPATH='${PYTHONPATH}:/tmp/faiss/build/faiss/python:/remote_vector_index_builder'
-
 RUN ["python", "test_imports.py"]
 CMD ["python", "core/main.py"]

--- a/remote_vector_index_builder/core/__init__.py
+++ b/remote_vector_index_builder/core/__init__.py
@@ -4,3 +4,4 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
+from .tasks import create_vectors_dataset, upload_index

--- a/remote_vector_index_builder/core/main.py
+++ b/remote_vector_index_builder/core/main.py
@@ -5,13 +5,47 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# TODO: Call each task from tasks.py in sequence, main()
-# Add this file as the entry point for the Dockerfile
+from core.common.models.index_build_parameters import IndexBuildParameters
+import time
+from core import create_vectors_dataset, upload_index
+import logging
+from io import BytesIO
+
+
+def configure_logging(log_level):
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
 
 def main():
-    pass
+    index_build_params = {
+        "repository_type": "s3",
+        "container_name": "testbucket-rchital",
+        "vector_path": "target_field__53.knnvec",
+        "doc_id_path": "target_field__53.knndid",
+        "dimension": 1000,
+        "doc_count": 76800,
+    }
+
+    vector_bytes_buffer = BytesIO()
+    doc_id_bytes_buffer = BytesIO()
+    model = IndexBuildParameters.model_validate(index_build_params)
+    start_time = time.time()
+    create_vectors_dataset(
+        model, {"debug": True}, vector_bytes_buffer, doc_id_bytes_buffer
+    )
+    end_time = time.time()
+    print(end_time - start_time)
+
+    # start_time = time.time()
+    # upload_index(model, {'debug': True}, "./target_field__53.knnvec")
+    # end_time = time.time()
+    # print(end_time - start_time)
 
 
 if __name__ == "__main__":
+    configure_logging("INFO")
     main()

--- a/remote_vector_index_builder/core/main.py
+++ b/remote_vector_index_builder/core/main.py
@@ -10,6 +10,7 @@ import time
 from core import create_vectors_dataset, upload_index
 import logging
 from io import BytesIO
+import os
 
 
 def configure_logging(log_level):
@@ -21,13 +22,19 @@ def configure_logging(log_level):
 
 
 def main():
+
+    knn_vec = os.environ.get('KNN_VEC')
+    knn_did = os.environ.get('KNN_DID')
+    dimension = os.environ.get('DIMENSION')
+    doc_count = os.environ.get('DOC_COUNT')
+
     index_build_params = {
         "repository_type": "s3",
         "container_name": "testbucket-rchital",
-        "vector_path": "target_field__53.knnvec",
-        "doc_id_path": "target_field__53.knndid",
-        "dimension": 1000,
-        "doc_count": 76800,
+        "vector_path": knn_vec,
+        "doc_id_path": knn_did,
+        "dimension": dimension,
+        "doc_count": doc_count,
     }
 
     vector_bytes_buffer = BytesIO()

--- a/remote_vector_index_builder/test_imports.py
+++ b/remote_vector_index_builder/test_imports.py
@@ -4,11 +4,11 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-
 def test_imports():
     try:
         from core import create_vectors_dataset
         from core import upload_index
+        import faiss
         # etc.
         print("All imports successful!")
         return 0

--- a/remote_vector_index_builder/test_imports.py
+++ b/remote_vector_index_builder/test_imports.py
@@ -1,0 +1,21 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+def test_imports():
+    try:
+        from core import create_vectors_dataset
+        from core import upload_index
+        # etc.
+        print("All imports successful!")
+        return 0
+    except ImportError as e:
+        print(f"Import failed: {e}")
+        exit(1)
+
+if __name__ == "__main__":
+    test_imports()
+


### PR DESCRIPTION
### Description
Added components to create `core` Remote Vector Index Builder docker image. This PR is a work in progress, and is still awaiting completion of the `build_index` task targeted by this PR: https://github.com/opensearch-project/remote-vector-index-builder/pull/16. It also needs to use a different base image. 

I pulled the current base image from here: https://hub.docker.com/r/rchitale7/remote-index-build-service/tags

### Issues Resolved
Related to this issue: https://github.com/opensearch-project/remote-vector-index-builder/issues/20

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).