### PR TITLE
Adding ef_search to index_build_parameters

### DIFF
--- a/remote_vector_index_builder/core/common/models/index_build_parameters.py
+++ b/remote_vector_index_builder/core/common/models/index_build_parameters.py
@@ -63,6 +63,8 @@ class AlgorithmParameters(BaseModel):
         ef_construction (int): Size of the dynamic candidate list for constructing
             the HNSW graph. Higher values lead to better quality but slower
             index construction. Defaults to 100.
+        ef_search (int): The size of the dynamic list used during k-NN searches.
+            Higher values result in more accurate but slower searches.
         m (int): Number of bi-directional links created for every new element
             during construction. Higher values lead to better search speed but
             more memory consumption. Defaults to 16.
@@ -71,6 +73,7 @@ class AlgorithmParameters(BaseModel):
     """
 
     ef_construction: int = 100
+    ef_search: int = 100
     m: int = 16
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
### Description
Need to match the default parameters specified in the API contract: https://github.com/opensearch-project/remote-vector-index-builder/blob/main/API.md. `ef_search` was missing, so adding it here


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).