### PR TITLE
Add support for local stack

### DIFF
--- a/.github/workflows/publish_remote_core_image.yml
+++ b/.github/workflows/publish_remote_core_image.yml
@@ -54,3 +54,5 @@ jobs:
         if: always()
         run: |
           docker logout
+  build-and-publish-api-image:
+    uses: ./.github/workflows/publish_remote_api_image.yml

--- a/remote_vector_index_builder/app/services/index_builder.py
+++ b/remote_vector_index_builder/app/services/index_builder.py
@@ -6,6 +6,7 @@
 # compatible open source license.
 
 import logging
+import os
 from typing import Optional, Tuple
 from app.models.workflow import BuildWorkflow
 from core.tasks import run_tasks
@@ -33,7 +34,10 @@ class IndexBuilder:
                 - Index path if successful, None otherwise
                 - Error message if failed, None otherwise
         """
-        result = run_tasks(workflow.index_build_parameters)
+        integration_tests = os.environ.get("INTEGRATION_TESTS", None)
+        result = run_tasks(
+            workflow.index_build_parameters, {"integration_tests": integration_tests}
+        )
         if not result.file_name:
             return False, None, result.error
         return True, result.file_name, None

--- a/remote_vector_index_builder/app/services/index_builder.py
+++ b/remote_vector_index_builder/app/services/index_builder.py
@@ -34,9 +34,9 @@ class IndexBuilder:
                 - Index path if successful, None otherwise
                 - Error message if failed, None otherwise
         """
-        integration_tests = os.environ.get("INTEGRATION_TESTS", None)
+        s3_endpoint_url = os.environ.get("S3_ENDPOINT_URL", None)
         result = run_tasks(
-            workflow.index_build_parameters, {"integration_tests": integration_tests}
+            workflow.index_build_parameters, {"S3_ENDPOINT_URL": s3_endpoint_url}
         )
         if not result.file_name:
             return False, None, result.error

--- a/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
+++ b/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
@@ -12,7 +12,7 @@ from functools import cache
 import math
 from io import BytesIO
 import sys
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import boto3
 from boto3.s3.transfer import TransferConfig
@@ -46,17 +46,27 @@ def get_cpus(factor: float) -> int:
 
 
 @cache
-def get_boto3_client(region: str, retries: int) -> boto3.client:
+def get_boto3_client(
+    region: str, retries: int, integration_tests: Optional[str] = None
+) -> boto3.client:
     """Create or retrieve a cached boto3 S3 client.
 
     Args:
         region (str): AWS region name for the S3 client
         retries (int): Maximum number of retry attempts for failed requests
+        integration_tests (str): Determines if s3 local stack should be used, for integration tests
 
     Returns:
         boto3.client: Configured S3 client instance
     """
     config = Config(retries={"max_attempts": retries})
+    if integration_tests and integration_tests.lower() not in ("false", "0", "f"):
+        return boto3.client(
+            "s3",
+            config=config,
+            region_name=region,
+            endpoint_url=S3ObjectStore.LOCAL_STACK_ENDPOINT,
+        )
     return boto3.client("s3", config=config, region_name=region)
 
 
@@ -75,11 +85,15 @@ class S3ObjectStore(ObjectStore):
             Includes encryption and checksum settings.
         DEFAULT_UPLOAD_ARGS (dict): Default boto3 ALLOWED_UPLOAD_ARGS values.
             Includes encryption and checksum settings
+        LOCAL_STACK_ENDPOINT (str): Endpoint URL for LocalStack S3 service used during
+            integration testing (default: 'http://172.17.0.1:4566')
 
     Args:
         index_build_params (IndexBuildParameters): Parameters for the index building process
         object_store_config (Dict[str, Any]): Configuration options for S3 interactions
     """
+
+    LOCAL_STACK_ENDPOINT = "http://172.17.0.1:4566"
 
     def __init__(
         self,
@@ -122,7 +136,11 @@ class S3ObjectStore(ObjectStore):
         self.max_retries = object_store_config.get("retries", 3)
         self.region = object_store_config.get("region", "us-west-2")
 
-        self.s3_client = get_boto3_client(region=self.region, retries=self.max_retries)
+        self.s3_client = get_boto3_client(
+            region=self.region,
+            retries=self.max_retries,
+            integration_tests=object_store_config.get("integration_tests"),
+        )
 
         download_transfer_config = object_store_config.get(
             "download_transfer_config", {}

--- a/test_remote_vector_index_builder/test_app/test_services/test_index_builder.py
+++ b/test_remote_vector_index_builder/test_app/test_services/test_index_builder.py
@@ -35,7 +35,7 @@ def test_build_index_success(index_builder, mock_workflow):
         assert success is True
         assert path == "/path/to/index"
         assert error is None
-        mock_run_tasks.assert_called_once_with(mock_workflow.index_build_parameters)
+        mock_run_tasks.assert_called_once()
 
 
 def test_build_index_failure(index_builder, mock_workflow):
@@ -51,4 +51,4 @@ def test_build_index_failure(index_builder, mock_workflow):
         assert success is False
         assert path is None
         assert error == "Build failed"
-        mock_run_tasks.assert_called_once_with(mock_workflow.index_build_parameters)
+        mock_run_tasks.assert_called_once()

--- a/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
+++ b/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
@@ -60,6 +60,26 @@ def test_get_boto3_client():
         assert mock_client.call_count == 2
 
 
+def test_get_boto3_client_with_local_stack():
+    with patch("boto3.client") as mock_client:
+        # Test caching behavior
+        get_boto3_client("us-west-2", 3, "t")
+        args = mock_client.call_args.kwargs
+        assert args["endpoint_url"] == S3ObjectStore.LOCAL_STACK_ENDPOINT
+
+        get_boto3_client("us-west-2", 3, "f")
+        args = mock_client.call_args.kwargs
+        assert "endpoint_url" not in args
+
+        get_boto3_client("us-west-2", 3, "false")
+        args = mock_client.call_args.kwargs
+        assert "endpoint_url" not in args
+
+        get_boto3_client("us-west-2", 3, "0")
+        args = mock_client.call_args.kwargs
+        assert "endpoint_url" not in args
+
+
 def test_s3_object_store_initialization(index_build_parameters, object_store_config):
     with patch("core.object_store.s3.s3_object_store.get_boto3_client"):
         store = S3ObjectStore(index_build_parameters, object_store_config)

--- a/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
+++ b/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
@@ -59,25 +59,8 @@ def test_get_boto3_client():
         get_boto3_client("us-east-1", 3)
         assert mock_client.call_count == 2
 
-
-def test_get_boto3_client_with_local_stack():
-    with patch("boto3.client") as mock_client:
-        # Test caching behavior
-        get_boto3_client("us-west-2", 3, "t")
-        args = mock_client.call_args.kwargs
-        assert args["endpoint_url"] == S3ObjectStore.LOCAL_STACK_ENDPOINT
-
-        get_boto3_client("us-west-2", 3, "f")
-        args = mock_client.call_args.kwargs
-        assert "endpoint_url" not in args
-
-        get_boto3_client("us-west-2", 3, "false")
-        args = mock_client.call_args.kwargs
-        assert "endpoint_url" not in args
-
-        get_boto3_client("us-west-2", 3, "0")
-        args = mock_client.call_args.kwargs
-        assert "endpoint_url" not in args
+        get_boto3_client("us-east-1", 3, "test-url")
+        assert mock_client.call_count == 3
 
 
 def test_s3_object_store_initialization(index_build_parameters, object_store_config):


### PR DESCRIPTION
### Description
Enables the API handlers to run during integration tests. Integration tests do not use s3 bucket, but rather a 'local stack' endpoint. This PR allows an environment variable to be passed to the API handler docker image that determines whether to use local stack or not. For running the integration tests, we will set this environment variable to true. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).