### PR TITLE
Add on workflow_call to publish_remote_api_image GitHub CI

### DIFF
--- a/.github/workflows/publish_remote_api_image.yml
+++ b/.github/workflows/publish_remote_api_image.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - 'remote_vector_index_builder/app/**'
       - '.github/workflows/publish_remote_api_image.yml'
+  workflow_call: # enables workflow to be reused
+    secrets:
+      REMOTE_VECTOR_DOCKER_USERNAME:
+        required: true
+      REMOTE_VECTOR_DOCKER_ROLE:
+        required: true
 
 permissions:
   id-token: write

--- a/.github/workflows/publish_remote_core_image.yml
+++ b/.github/workflows/publish_remote_core_image.yml
@@ -56,3 +56,6 @@ jobs:
           docker logout
   build-and-publish-api-image:
     uses: ./.github/workflows/publish_remote_api_image.yml
+    secrets:
+      REMOTE_VECTOR_DOCKER_ROLE: ${{ secrets.REMOTE_VECTOR_DOCKER_ROLE }}
+      REMOTE_VECTOR_DOCKER_USERNAME: ${{ secrets.REMOTE_VECTOR_DOCKER_USERNAME }}


### PR DESCRIPTION
### Description
The github CI for `publish_remote_core_image` was broken, due to the way we were calling `publish_remote_api_image` as a sub workflow. This change fixes the CI, passing in the docker secrets and adding the `on workflow_call` to `publish_remote_api_image`. This enables `publish_remote_api_image` to be used as a sub workflow for `publish_remote_core_image`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).