### PR TITLE
Add publish core image step as a dependency to publish api image step

### DIFF
--- a/.github/workflows/publish_remote_core_image.yml
+++ b/.github/workflows/publish_remote_core_image.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           docker logout
   build-and-publish-api-image:
+    needs: build-and-publish-core-image
     uses: ./.github/workflows/publish_remote_api_image.yml
     secrets:
       REMOTE_VECTOR_DOCKER_ROLE: ${{ secrets.REMOTE_VECTOR_DOCKER_ROLE }}


### PR DESCRIPTION
### Description
This change ensures that the `core` image is first published to opensearch staging, before being used as the base image for the `api` image docker build. Note that this will only happen when there is a change in the `core/` folder. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).