### PR TITLE
Fix broken link

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ Do not creating branches in the upstream repo, use your fork, for the exception 
 
 ## Versioning
 
-All distributions in this organization [follow SemVer](https://opensearch.org/blog/technical-post/2021/08/what-is-semver/). A user-facing breaking change can only be made in a major release. Any regression that breaks SemVer is considered a high severity bug.
+All distributions in this organization [follow SemVer](https://opensearch.org/blog/what-is-semver/). A user-facing breaking change can only be made in a major release. Any regression that breaks SemVer is considered a high severity bug.
 
 ### Version Numbers
 


### PR DESCRIPTION
### Description
Fixing broken link causing link checker workflow to fail. Github Action was failing due to this issue: https://github.com/opensearch-project/remote-vector-index-builder/actions/runs/14497793095

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).