### PR TITLE
Add mmap based storage of vectors, while keeping buffered storage as default

### DIFF
--- a/remote_vector_index_builder/app/services/index_builder.py
+++ b/remote_vector_index_builder/app/services/index_builder.py
@@ -35,8 +35,11 @@ class IndexBuilder:
                 - Error message if failed, None otherwise
         """
         s3_endpoint_url = os.environ.get("S3_ENDPOINT_URL", None)
+        storage_mode = os.environ.get("STORAGE_MODE", "memory")
         result = run_tasks(
-            workflow.index_build_parameters, {"S3_ENDPOINT_URL": s3_endpoint_url}
+            workflow.index_build_parameters,
+            {"S3_ENDPOINT_URL": s3_endpoint_url},
+            storage_mode,
         )
         if not result.file_name:
             return False, None, result.error

--- a/remote_vector_index_builder/core/binary_source/__init__.py
+++ b/remote_vector_index_builder/core/binary_source/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/remote_vector_index_builder/core/binary_source/binary_source.py
+++ b/remote_vector_index_builder/core/binary_source/binary_source.py
@@ -1,0 +1,46 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+from abc import ABC, abstractmethod
+
+from core.object_store.object_store import ObjectStore
+from numpy.typing import NDArray
+
+
+class BinarySource(ABC):
+
+    @abstractmethod
+    def __enter__(self):
+        pass
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    @abstractmethod
+    def read_from_object_store(
+        self, object_store: ObjectStore, object_store_path: str
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def parse(self, dtype: str) -> NDArray:
+        pass
+
+    def transform_to_numpy_array(
+        self,
+        object_store: ObjectStore,
+        object_store_path: str,
+        dtype: str,
+        expected_length: int,
+    ) -> NDArray:
+        self.read_from_object_store(object_store, object_store_path)
+        np_array = self.parse(dtype)
+        if len(np_array) != expected_length:
+            raise ValueError(
+                f"Expected {expected_length} vectors, but got {len(np_array)}"
+            )
+        return np_array

--- a/remote_vector_index_builder/core/binary_source/binary_source_factory.py
+++ b/remote_vector_index_builder/core/binary_source/binary_source_factory.py
@@ -1,0 +1,26 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+from core.binary_source.buffer_source import BufferSource
+from core.binary_source.file_source import FileSource
+from enum import Enum
+
+
+class StorageMode(str, Enum):
+    MEMORY = "memory"
+    DISK = "disk"
+
+
+class BinarySourceFactory:
+    @staticmethod
+    def create_binary_source(storage_mode: StorageMode):
+        if storage_mode == StorageMode.MEMORY:
+            return BufferSource()
+        elif storage_mode == StorageMode.DISK:
+            return FileSource()
+        else:
+            raise ValueError(f"Unsupported storage mode: {storage_mode}")

--- a/remote_vector_index_builder/core/binary_source/buffer_source.py
+++ b/remote_vector_index_builder/core/binary_source/buffer_source.py
@@ -1,0 +1,34 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+from core.binary_source.binary_source import BinarySource
+from core.object_store.object_store import ObjectStore
+
+from io import BytesIO
+import numpy as np
+from numpy.typing import NDArray
+
+
+class BufferSource(BinarySource):
+    def __init__(self):
+        self._source = BytesIO()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._source.close()
+
+    def read_from_object_store(
+        self, object_store: ObjectStore, object_store_path: str
+    ) -> None:
+        object_store.read_blob(object_store_path, self._source)
+
+    def parse(self, dtype: str) -> NDArray:
+        vector_view = self._source.getbuffer()
+        np_array = np.frombuffer(vector_view, dtype=dtype)
+        return np_array

--- a/remote_vector_index_builder/core/binary_source/file_source.py
+++ b/remote_vector_index_builder/core/binary_source/file_source.py
@@ -1,0 +1,40 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+from core.binary_source.binary_source import BinarySource
+from core.object_store.object_store import ObjectStore
+
+from tempfile import TemporaryDirectory
+import numpy as np
+from numpy.typing import NDArray
+
+
+class FileSource(BinarySource):
+    def __init__(self):
+        self._temp_dir = None
+        self._source = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._source is not None:
+            self._source.close()
+        if self._temp_dir is not None:
+            self._temp_dir.cleanup()
+
+    def read_from_object_store(
+        self, object_store: ObjectStore, object_store_path: str
+    ) -> None:
+        filename = object_store_path.replace("/", "_").replace("\\", "_")
+        self._temp_dir = TemporaryDirectory()
+        self._source = open(f"{self._temp_dir.name}/{filename}", "wb+")
+        object_store.read_blob(object_store_path, self._source)
+
+    def parse(self, dtype: str) -> NDArray:
+        np_array = np.memmap(self._source, dtype=dtype, mode="r+")
+        return np_array

--- a/remote_vector_index_builder/core/common/exceptions.py
+++ b/remote_vector_index_builder/core/common/exceptions.py
@@ -21,16 +21,3 @@ class UnsupportedObjectStoreTypeError(ValueError):
     """Error raised when creating an Object Store object"""
 
     pass
-
-
-class VectorsDatasetError(Exception):
-    """Generic error raised when converting a buffer into a Vector Dataset"""
-
-    def __init__(self, message: str):
-        super().__init__(message)
-
-
-class UnsupportedVectorsDataTypeError(ValueError):
-    """Error raised when creating a Vector Dataset because of unsupported data type"""
-
-    pass

--- a/remote_vector_index_builder/core/common/models/vectors_dataset.py
+++ b/remote_vector_index_builder/core/common/models/vectors_dataset.py
@@ -6,20 +6,13 @@
 # compatible open source license.
 
 from dataclasses import dataclass
-from io import BytesIO
 
 import numpy as np
-from core.common.exceptions import UnsupportedVectorsDataTypeError, VectorsDatasetError
-from core.common.models.index_build_parameters import DataType
 
 
 @dataclass
 class VectorsDataset:
     """A class for handling vector datasets and their associated document IDs.
-
-    This class provides functionality to parse, validate, and store vector data along with
-    their corresponding document IDs. It supports multiple data types including FLOAT32,
-    FLOAT16, BYTE, and BINARY formats.
 
     Attributes:
         vectors (numpy.ndarray): The array of vectors, where each row represents a vector.
@@ -40,82 +33,3 @@ class VectorsDataset:
             del self.doc_ids
         except AttributeError:
             pass
-        return
-
-    @staticmethod
-    def get_numpy_dtype(dtype: DataType):
-        """Convert DataType enum to numpy dtype string.
-
-        Args:
-            dtype (DataType): The data type enum value to convert.
-
-        Returns:
-            str: The corresponding numpy dtype string.
-
-        Raises:
-            UnsupportedVectorsDataTypeError: If the provided data type is not supported.
-        """
-        if dtype == DataType.FLOAT:
-            return "<f4"
-        else:
-            raise UnsupportedVectorsDataTypeError(f"Unsupported data type: {dtype}")
-
-    @staticmethod
-    def check_dimensions(vectors, expected_length):
-        """Validate that the vector array has the expected length.
-
-        Args:
-            vectors: Array-like object to check.
-            expected_length (int): The expected length of the vectors array.
-
-        Raises:
-            VectorsDatasetError: If the vectors length doesn't match the expected length.
-        """
-        if len(vectors) != expected_length:
-            raise VectorsDatasetError(
-                f"Expected {expected_length} vectors, but got {len(vectors)}"
-            )
-
-    @staticmethod
-    def parse(
-        vectors: BytesIO,
-        doc_ids: BytesIO,
-        dimension: int,
-        doc_count: int,
-        vector_dtype: DataType,
-    ):
-        """Parse binary vector data and document IDs into numpy arrays.
-
-        This method reads binary data for vectors and document IDs, validates their
-        dimensions, and creates a new VectorsDataset instance.
-
-        Args:
-            vectors (BytesIO): Binary stream containing vector data.
-            doc_ids (BytesIO): Binary stream containing document IDs.
-            dimension (int): The dimensionality of each vector.
-            doc_count (int): Expected number of vectors/documents.
-            vector_dtype (DataType): The data type of the vector values.
-
-        Returns:
-            VectorsDataset: A new instance containing the parsed vectors and document IDs.
-
-        Raises:
-            VectorsDatasetError: If there are any errors during parsing or validation.
-        """
-        try:
-            # Create a view into the buffer, to prevent additional allocation of memory
-            vector_view = vectors.getbuffer()
-            np_vectors = np.frombuffer(
-                vector_view, dtype=VectorsDataset.get_numpy_dtype(vector_dtype)
-            )
-            VectorsDataset.check_dimensions(np_vectors, doc_count * dimension)
-            np_vectors = np_vectors.reshape(doc_count, dimension)
-
-            # Do the same for doc ids
-            doc_id_view = doc_ids.getbuffer()
-            np_doc_ids = np.frombuffer(doc_id_view, dtype="<i4")
-            VectorsDataset.check_dimensions(np_doc_ids, doc_count)
-
-        except (ValueError, TypeError, MemoryError, RuntimeError) as e:
-            raise VectorsDatasetError(f"Error parsing vectors: {e}") from e
-        return VectorsDataset(np_vectors, np_doc_ids)

--- a/remote_vector_index_builder/core/object_store/object_store.py
+++ b/remote_vector_index_builder/core/object_store/object_store.py
@@ -6,7 +6,7 @@
 # compatible open source license.
 
 from abc import ABC, abstractmethod
-from io import BytesIO
+from typing import IO
 
 
 class ObjectStore(ABC):
@@ -21,20 +21,20 @@ class ObjectStore(ABC):
     """
 
     @abstractmethod
-    def read_blob(self, remote_store_path: str, bytes_buffer: BytesIO) -> None:
+    def read_blob(self, remote_store_path: str, file_obj: IO[bytes]) -> None:
         """
-        Downloads the blob from the remote_store_path, to a buffer in memory
+        Downloads a blob from remote store to the provided file object.
 
         Args:
             remote_store_path (str): The path/key to the remote object to be downloaded
-            bytes_buffer (BytesIO): A bytes buffer where the downloaded data will be stored
+            file_obj (IO[bytes]): A file-like object opened in binary mode to store the downloaded data
 
         Returns:
             None
 
         Note:
-            - The bytes_buffer should be properly initialized before passing to this method
-            - Caller is also responsible for cleaning up the bytes buffer
+            - The file object should be properly initialized before passing to this method
+            - Caller is also responsible for closing the file object
             - Implementations should handle any necessary authentication and error handling
         """
         pass

--- a/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
+++ b/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
@@ -10,9 +10,8 @@ import os
 import threading
 from functools import cache
 import math
-from io import BytesIO
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, IO
 
 import boto3
 from boto3.s3.transfer import TransferConfig
@@ -202,13 +201,13 @@ class S3ObjectStore(ObjectStore):
 
         return config_params
 
-    def read_blob(self, remote_store_path: str, bytes_buffer: BytesIO) -> None:
+    def read_blob(self, remote_store_path: str, file_obj: IO[bytes]) -> None:
         """
-        Downloads a blob from S3 to the provided bytes buffer, with retry logic.
+        Downloads a blob from S3 to the provided file object, with retry logic.
 
         Args:
             remote_store_path (str): The S3 key (path) of the object to download
-            bytes_buffer (BytesIO): A bytes buffer to store the downloaded data
+            file_obj (IO[bytes]): A file-like object opened in binary mode to store the downloaded data
 
         Returns:
             None
@@ -246,7 +245,7 @@ class S3ObjectStore(ObjectStore):
             self.s3_client.download_fileobj(
                 self.bucket,
                 remote_store_path,
-                bytes_buffer,
+                file_obj,
                 Config=s3_transfer_config,
                 Callback=callback_func,
                 ExtraArgs=self.download_args,

--- a/test_remote_vector_index_builder/test_core/common/models/test_vectors_dataset.py
+++ b/test_remote_vector_index_builder/test_core/common/models/test_vectors_dataset.py
@@ -4,13 +4,9 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-from io import BytesIO
-from unittest.mock import patch
 
 import numpy as np
 import pytest
-from core.common.exceptions import UnsupportedVectorsDataTypeError, VectorsDatasetError
-from core.common.models.index_build_parameters import DataType
 from core.common.models.vectors_dataset import VectorsDataset
 
 
@@ -36,112 +32,3 @@ def test_free_vectors_space_when_vectors_and_doc_ids_already_deleted(vectors_dat
         _ = vectors_dataset.doc_ids
     # test idempotency
     vectors_dataset.free_vectors_space()
-
-
-@pytest.mark.parametrize(
-    "dtype, expected",
-    [
-        (DataType.FLOAT, "<f4"),
-    ],
-)
-def test_get_numpy_dtype_valid(dtype, expected):
-    assert VectorsDataset.get_numpy_dtype(dtype) == expected
-
-
-def test_get_numpy_dtype_invalid():
-    with pytest.raises(UnsupportedVectorsDataTypeError):
-        VectorsDataset.get_numpy_dtype("invalid_dtype")
-
-
-def test_check_dimensions_valid():
-    vectors = np.zeros(5)
-    VectorsDataset.check_dimensions(vectors, 5)  # Should not raise
-
-
-def test_check_dimensions_invalid():
-    vectors = np.zeros(5)
-    with pytest.raises(VectorsDatasetError):
-        VectorsDataset.check_dimensions(vectors, 10)
-
-
-def test_parse_valid_data(sample_vectors, sample_doc_ids):
-    # Prepare test data
-    dimension = len(sample_vectors[0])
-    doc_count = len(sample_vectors)
-    vector_dtype = DataType.FLOAT
-
-    # Convert to binary
-    vectors_binary = BytesIO(sample_vectors.tobytes())
-    doc_ids_binary = BytesIO(sample_doc_ids.tobytes())
-
-    # Parse
-    dataset = VectorsDataset.parse(
-        vectors=vectors_binary,
-        doc_ids=doc_ids_binary,
-        dimension=dimension,
-        doc_count=doc_count,
-        vector_dtype=vector_dtype,
-    )
-
-    # Verify
-    assert isinstance(dataset, VectorsDataset)
-    assert dataset.vectors.shape == (doc_count, dimension)
-    assert len(dataset.doc_ids) == doc_count
-    assert len(dataset.vectors) == doc_count
-    assert np.array_equal(dataset.doc_ids, sample_doc_ids)
-    assert np.array_equal(dataset.vectors, sample_vectors)
-
-    dataset.free_vectors_space()
-    vectors_binary.close()
-    doc_ids_binary.close()
-
-
-def test_parse_invalid_doc_count():
-    with pytest.raises(VectorsDatasetError):
-        vectors = BytesIO(np.zeros(6, dtype="<f4").tobytes())
-        doc_ids = BytesIO(np.array([1, 2, 3, 4, 5, 6], dtype="<i4").tobytes())
-        dataset = VectorsDataset.parse(
-            vectors=vectors,
-            doc_ids=doc_ids,
-            dimension=1,
-            doc_count=5,
-            vector_dtype=DataType.FLOAT,
-        )
-        dataset.free_vectors_space()
-        vectors.close()
-        doc_ids.close()
-
-
-def test_parse_invalid_vector_dimensions():
-    with pytest.raises(VectorsDatasetError):
-        vectors = BytesIO(np.zeros(5, dtype="<f4").tobytes())
-        doc_ids = BytesIO(np.array([1, 2, 3, 4, 5], dtype="<i4").tobytes())
-        dataset = VectorsDataset.parse(
-            vectors=vectors,
-            doc_ids=doc_ids,
-            dimension=2,  # Expecting 10 values (5*2), but only provided 5
-            doc_count=5,
-            vector_dtype=DataType.FLOAT,
-        )
-        dataset.free_vectors_space()
-        vectors.close()
-        doc_ids.close()
-
-
-#
-def test_parse_invalid_data():
-    with patch("numpy.frombuffer") as mock_frombuffer:
-        mock_frombuffer.side_effect = ValueError("Invalid data")
-        with pytest.raises(VectorsDatasetError):
-            vectors = BytesIO(np.zeros(6, dtype="<f4").tobytes())
-            doc_ids = BytesIO(np.array([1, 2, 3, 4, 5, 6], dtype="<i4").tobytes())
-            dataset = VectorsDataset.parse(
-                vectors=vectors,
-                doc_ids=doc_ids,
-                dimension=1,
-                doc_count=6,
-                vector_dtype=DataType.FLOAT,
-            )
-            dataset.free_vectors_space()
-            vectors.close()
-            doc_ids.close()

--- a/test_remote_vector_index_builder/test_core/test_binary_source/__init__.py
+++ b/test_remote_vector_index_builder/test_core/test_binary_source/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/test_remote_vector_index_builder/test_core/test_binary_source/test_binary_source_factory.py
+++ b/test_remote_vector_index_builder/test_core/test_binary_source/test_binary_source_factory.py
@@ -1,0 +1,28 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+import pytest
+from core.binary_source.buffer_source import BufferSource
+from core.binary_source.file_source import FileSource
+from core.binary_source.binary_source_factory import BinarySourceFactory, StorageMode
+
+
+def test_create_binary_source_memory():
+    """Test that StorageMode.MEMORY returns a BufferSource instance"""
+    source = BinarySourceFactory.create_binary_source(StorageMode.MEMORY)
+    assert isinstance(source, BufferSource)
+
+
+def test_create_binary_source_disk():
+    """Test that StorageMode.DISK returns a FileSource instance"""
+    source = BinarySourceFactory.create_binary_source(StorageMode.DISK)
+    assert isinstance(source, FileSource)
+
+
+def test_create_binary_source_unsupported():
+    """Test that an unsupported storage mode raises a ValueError"""
+    with pytest.raises(ValueError, match="Unsupported storage mode: unsupported_mode"):
+        BinarySourceFactory.create_binary_source("unsupported_mode")

--- a/test_remote_vector_index_builder/test_core/test_binary_source/test_buffer_source.py
+++ b/test_remote_vector_index_builder/test_core/test_binary_source/test_buffer_source.py
@@ -1,0 +1,57 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+import numpy as np
+from unittest.mock import Mock
+from io import BytesIO
+from core.binary_source.buffer_source import BufferSource
+from core.object_store.object_store import ObjectStore
+
+
+def test_init():
+    """Test that initialization creates a BytesIO object"""
+    buffer = BufferSource()
+    assert isinstance(buffer._source, BytesIO)
+
+
+def test_context_manager():
+    """Test context manager functionality (enter/exit)"""
+    # Use a context manager
+    with BufferSource() as buffer:
+        assert isinstance(buffer, BufferSource)
+        # Replace the _source with a mock to check if close is called
+        mock_source = Mock(wraps=buffer._source)
+        buffer._source = mock_source
+
+    # Verify close was called during exit
+    mock_source.close.assert_called_once()
+
+
+def test_read_from_object_store():
+    """Test reading data from an object store"""
+    mock_object_store = Mock(spec=ObjectStore)
+    buffer = BufferSource()
+
+    buffer.read_from_object_store(mock_object_store, "test/path")
+
+    # Verify object store read_blob was called with correct arguments
+    mock_object_store.read_blob.assert_called_once_with("test/path", buffer._source)
+
+
+def test_parse(sample_doc_ids):
+    """Test parsing buffer content into a NumPy array using sample_doc_ids fixture"""
+    buffer = BufferSource()
+
+    # Use fixture data
+    buffer._source = BytesIO(sample_doc_ids.tobytes())
+
+    # Parse the data
+    result = buffer.parse(dtype="int32")
+
+    # Verify result
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.dtype("int32")
+    np.testing.assert_array_equal(result, sample_doc_ids)

--- a/test_remote_vector_index_builder/test_core/test_binary_source/test_file_source.py
+++ b/test_remote_vector_index_builder/test_core/test_binary_source/test_file_source.py
@@ -1,0 +1,109 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+from unittest.mock import Mock, patch
+from core.binary_source.file_source import FileSource
+from core.object_store.object_store import ObjectStore
+
+
+def test_init():
+    """Test initialization sets the right defaults"""
+    file_source = FileSource()
+    assert file_source._temp_dir is None
+    assert file_source._source is None
+
+
+def test_context_manager():
+    """Test context manager functionality"""
+    # Mock the internal file and temp dir
+    with patch("core.binary_source.file_source.TemporaryDirectory") as mock_temp_dir:
+        mock_file = Mock()
+
+        # Create and enter context with file_source
+        with FileSource() as file_source:
+            file_source._source = mock_file
+            file_source._temp_dir = mock_temp_dir.return_value
+            assert isinstance(file_source, FileSource)
+
+        # Verify cleanup was done
+        mock_file.close.assert_called_once()
+        mock_temp_dir.return_value.cleanup.assert_called_once()
+
+
+def test_context_manager_with_none():
+    """Test context manager cleanup when source or temp_dir are None"""
+    # This test ensures the exit method handles None values safely
+    with FileSource():
+        # Intentionally leave _source and _temp_dir as None
+        pass
+
+    # No assertions needed; test passes if no exceptions are raised
+
+
+def test_read_from_object_store():
+    """Test reading data from an object store"""
+    mock_object_store = Mock(spec=ObjectStore)
+    file_source = FileSource()
+
+    # Use a patch to avoid actual file operations
+    with patch("builtins.open") as mock_open, patch(
+        "core.binary_source.file_source.TemporaryDirectory"
+    ) as mock_temp_dir:
+
+        mock_temp_dir.return_value.name = "/tmp/fake_dir"
+        mock_file = Mock()
+        mock_open.return_value = mock_file
+
+        # Call the method
+        file_source.read_from_object_store(mock_object_store, "test/path")
+
+        # Verify temp dir was created
+        mock_temp_dir.assert_called_once()
+        # Verify file was opened with correct path
+        mock_open.assert_called_with("/tmp/fake_dir/test_path", "wb+")
+        # Verify object store read_blob was called
+        mock_object_store.read_blob.assert_called_once_with("test/path", mock_file)
+
+
+def test_read_from_object_store_path_sanitization():
+    """Test path sanitization in read_from_object_store"""
+    mock_object_store = Mock(spec=ObjectStore)
+    file_source = FileSource()
+
+    with patch("builtins.open") as mock_open, patch(
+        "core.binary_source.file_source.TemporaryDirectory"
+    ) as mock_temp_dir:
+
+        mock_temp_dir.return_value.name = "/tmp/fake_dir"
+
+        # Test with path containing both forward and backward slashes
+        file_source.read_from_object_store(
+            mock_object_store, "test/path\\with/mixed\\slashes"
+        )
+
+        # Verify file was opened with sanitized path
+        mock_open.assert_called_with(
+            "/tmp/fake_dir/test_path_with_mixed_slashes", "wb+"
+        )
+
+
+def test_parse(sample_doc_ids):
+    """Test parsing file content into a NumPy array"""
+    file_source = FileSource()
+
+    with patch("numpy.memmap") as mock_memmap:
+        mock_memmap.return_value = sample_doc_ids
+        mock_file = Mock()
+        file_source._source = mock_file
+
+        # Parse the data
+        result = file_source.parse(dtype="int32")
+
+        # Verify numpy.memmap was called with correct params
+        mock_memmap.assert_called_once_with(mock_file, dtype="int32", mode="r+")
+
+        # Verify result
+        assert result is sample_doc_ids


### PR DESCRIPTION
### Description
This issue enables the vector and doc id binary downloaded from Remote Store to be saved to disk, and read using mmap. The caller of `run_tasks` can download the vectors to disk if they set `storage_mode` = "disk", but the default storage mode is still `memory`. I refactored the code so that we can support other storage modes if necessary. Key to the refactoring is the `BinarySource` object that wraps the storage mechanism; `FileSource` wraps the file object used for `numpy.mmap`, while `BufferSource` wraps the buffer object used for `numpy.frombuffer`. 

I verified manually that both storage modes work, and create the expected faiss graph.

### Issues Resolved
Partially resolves for https://github.com/opensearch-project/remote-vector-index-builder/issues/49. I need to still update the `USER_GUIDE.md` to specify that `memory` is the default approach, but with CUDA versions >= 12, we see memory spike. So to avoid memory spike, user can use `disk` (at the expense of slower index builds)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).