### PR TITLE
Update the documentation to specify authentication is not supported

### DIFF
--- a/API.md
+++ b/API.md
@@ -79,7 +79,10 @@ in the same root remote store path as the `vector_path`.
 
 ### Authentication
 
-If authentication is configured, the endpoint must support Basic Authentication. The server is expected to return a 401 Unauthorized status code if authentication is enabled and credentials are missing/incorrect. If there is no authentication configured, the server will process requests with no Authentication header.
+The Remote Vector Service endpoint can be configured with Basic Authentication. If authentication is configured and the credentials are missing/incorrect, the Remote Vector Service is expected to return a 401 Unauthorized status code. 
+If authentication is not configured, the Remote Vector Service will ignore the HTTP Authorization header. 
+
+Please note that the [default](/remote_vector_index_builder/app/) Remote Vector Service API Docker image does not support Basic Authentication configuration, so it will always ignore the HTTP Authorization header. 
 
 * * *
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -155,13 +155,8 @@ The API image implements the [Remote Vector Service API Contract](/API.md). It p
 that directly integrate with the OpenSearch k-NN Remote Vector Service Client. The default image
 configuration allows it to be used to run integration tests for the OpenSearch k-NN Remote Vector component.
 This configuration maintains the job state in an in-memory dictionary with a TTL, and uses a fixed size
-thread pool to execute index build workflows. 
-
-
-The dictionary size and TTL is controllable via the Docker container settings. For example, you can set the TTL
-to `None`, to ensure requests never get deleted. You are also free to implement a separate, custom API image, 
-as long as it conforms to the Remote Vector Service API Contract and provides endpoints for the Remote Vector Service Client. 
-This custom API image can still use the `core` image libraries to execute the index build workflow.
+thread pool to execute index build workflows. But, the dictionary size and TTL is also controllable via the Docker container settings. For example, you can set the TTL
+to `None`, to ensure requests never get deleted.
 
 Follow the steps below to use run the API image locally. Note that s3 is currently the only supported Remote Store repository
 1. [Provision an instance for development](#provisioning-an-instance-for-development)

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -30,3 +30,8 @@ If another Docker process is already running on this port, you may get an error 
 After successfully running the previous command, the remote build service will be available at the instance's public IP address on port 80 (or whichever port was chosen previously).
 
 For information on configuring OpenSearch to use this service, please refer to the [OpenSearch k-NN documentation.](https://docs.opensearch.org/docs/latest/vector-search/)
+
+## Additional Information
+
+You are free to implement a different API server, as long as it conforms to the [Remote Vector Service API Contract](/API.md).
+This custom API image can still use the `core` image libraries to execute the index build workflow.


### PR DESCRIPTION
### Description
Need to specify that current API image does not support auth. Also specified in `USER_GUIDE.md` that user is free to use custom API image, as long as it conforms to API contract


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).