### PR TITLE
Added get_jobs and heart_beat apis

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,10 +5,12 @@ on:
     paths:  # Note this is done for folder specific checkouts, reduce CI memory load
       - 'remote_vector_index_builder/**'
       - 'test_remote_vector_index_builder/**'
+      - 'e2e/**'
   pull_request:
     paths:  # Note this is done for folder specific checkouts, reduce CI memory load
       - 'remote_vector_index_builder/**'
       - 'test_remote_vector_index_builder/**'
+      - 'e2e/**'
 
 permissions:
   contents: read
@@ -29,6 +31,7 @@ jobs:
               .github/CODEOWNERS
               remote_vector_index_builder
               test_remote_vector_index_builder
+              e2e
         - name: Setup Python
           uses: actions/setup-python@v5
           with:
@@ -40,18 +43,19 @@ jobs:
             python -m pip install -r remote_vector_index_builder/core/requirements.txt
             python -m pip install -r remote_vector_index_builder/app/requirements.txt
             python -m pip install -r test_remote_vector_index_builder/requirements.txt
+            python -m pip install -r e2e/api/requirements.txt
 
         - name: Run Linting - flake8
           run: |
-            python -m flake8 remote_vector_index_builder/ test_remote_vector_index_builder/
+            python -m flake8 remote_vector_index_builder/ test_remote_vector_index_builder/ e2e/
 
         - name: Run Formatter - black
           run: |
-            python -m black --check remote_vector_index_builder/ test_remote_vector_index_builder/
+            python -m black --check remote_vector_index_builder/ test_remote_vector_index_builder/ e2e/
 
         - name: Run Type Checker - mypy
           run: |
-            python -m mypy remote_vector_index_builder/ test_remote_vector_index_builder/
+            python -m mypy remote_vector_index_builder/ test_remote_vector_index_builder/ e2e/
         - name: Run tests
           run: |
             python -m pytest test_remote_vector_index_builder/

--- a/e2e/__init__.py
+++ b/e2e/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/e2e/api/__init__.py
+++ b/e2e/api/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/e2e/api/remote_vector_api_client.py
+++ b/e2e/api/remote_vector_api_client.py
@@ -97,6 +97,40 @@ class RemoteVectorAPIClient:
             logger.error(f"Failed to get status for job {job_id}")
             raise
 
+    def heart_beat(self) -> str:
+        """
+        Method to make a _heart_beat request to the API server
+        Returns:
+            str: Heart beat response message
+
+        Raises:
+            APIError: If the _heart_beat request fails
+        """
+        logger = logging.getLogger(__name__)
+        try:
+            response = self._make_request(method="GET", endpoint="/_heart_beat")
+            return response.json()
+        except APIError:
+            logger.error("Failed to get heartbeat")
+            raise
+
+    def get_jobs(self) -> str:
+        """
+        Method to make a _jobs request to the API server
+        Returns:
+            str: Jobs that are currently stored on the server
+
+        Raises:
+            APIError: If the _jobs request fails
+        """
+        logger = logging.getLogger(__name__)
+        try:
+            response = self._make_request(method="GET", endpoint="/_jobs")
+            return response.json()
+        except APIError:
+            logger.error("Failed to get heartbeat")
+            raise
+
     def build_index(self, index_build_parameters: Dict[str, Any]) -> str:
         """
         Submits an Index Build Job via HTTP request to the _build API
@@ -150,7 +184,7 @@ class RemoteVectorAPIClient:
                 error_detail = None
                 try:
                     error_detail = e.response.json()
-                except:
+                except Exception:
                     error_detail = e.response.text
 
                 logger.error(

--- a/e2e/api/requirements.txt
+++ b/e2e/api/requirements.txt
@@ -1,1 +1,3 @@
-PyYAML>=6.0.2
+PyYAML>=6.0.2,<6.1
+types-PyYAML>=6.0.2,<6.1
+types-requests>=2.32,<2.33

--- a/e2e/api/utils/__init__.py
+++ b/e2e/api/utils/__init__.py
@@ -1,0 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.

--- a/e2e/api/vector_dataset_generator.py
+++ b/e2e/api/vector_dataset_generator.py
@@ -16,6 +16,7 @@ from core.object_store.types import ObjectStoreType
 import logging
 from tqdm import tqdm
 
+
 class VectorDatasetGenerator:
     """
     Class to generate dummy vectors and injest in the object store, required for running e2e tests

--- a/remote_vector_index_builder/app/main.py
+++ b/remote_vector_index_builder/app/main.py
@@ -35,7 +35,7 @@ Dependencies:
     - app.storage: Storage implementations
     - app.utils: Utility functions and logging
 """
-from app.routes import build, status
+from app.routes import build, status, heart_beat, get_jobs
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -114,3 +114,5 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 app.include_router(build.router)
 app.include_router(status.router)
+app.include_router(heart_beat.router)
+app.include_router(get_jobs.router)

--- a/remote_vector_index_builder/app/routes/get_jobs.py
+++ b/remote_vector_index_builder/app/routes/get_jobs.py
@@ -1,0 +1,35 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+from fastapi import APIRouter, Request
+import json
+
+import logging
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/_jobs")
+def get_jobs(request: Request) -> str:
+    """
+    Retrieve all jobs from the job service.
+
+    This endpoint returns a list of all jobs in the system. The jobs are retrieved
+    from the job service stored in the application state and serialized to JSON.
+
+    Args:
+        request (Request): The request object containing the application state
+                         with the job service.
+
+    Returns:
+        str: A JSON string containing all jobs, with each job's attributes serialized
+             into a readable format with proper indentation.
+
+    """
+    job_service = request.app.state.job_service
+    jobs = job_service.get_jobs()
+    return json.dumps(jobs, default=lambda o: o.__dict__, indent=4)

--- a/remote_vector_index_builder/app/routes/heart_beat.py
+++ b/remote_vector_index_builder/app/routes/heart_beat.py
@@ -1,0 +1,28 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+from fastapi import APIRouter
+from app.base.config import Settings
+
+import logging
+
+router = APIRouter()
+settings = Settings()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/_heart_beat")
+def heart_beat() -> str:
+    """
+    Health check endpoint to verify the service is running.
+
+    This endpoint provides a simple health check mechanism to verify that the service
+    is up and responding to requests.
+
+    Returns:
+        str: A simple response indicating the service is alive and responding.
+    """
+    return settings.service_name

--- a/remote_vector_index_builder/app/services/job_service.py
+++ b/remote_vector_index_builder/app/services/job_service.py
@@ -5,7 +5,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from typing import Optional
+from typing import Optional, Dict
 from app.base.exceptions import HashCollisionError, CapacityError
 from app.base.resources import ResourceManager
 from app.executors.workflow_executor import WorkflowExecutor
@@ -215,3 +215,12 @@ class JobService:
             Optional[Job]: The job object if found, None otherwise
         """
         return self.request_store.get(job_id)
+
+    def get_jobs(self) -> Dict[str, Job]:
+        """
+        Retrieves all jobs from the request store.
+
+        Returns:
+            Dict[str, Job]: A dictionary of all jobs in the request store
+        """
+        return self.request_store.get_jobs()

--- a/remote_vector_index_builder/app/storage/base.py
+++ b/remote_vector_index_builder/app/storage/base.py
@@ -73,3 +73,13 @@ class RequestStore(ABC):
             bool: True if deletion was successful, False otherwise
         """
         return True
+
+    @abstractmethod
+    def get_jobs(self) -> Dict[str, Job]:
+        """
+        Retrieve all jobs from the store.
+
+        Returns:
+            Dict[str, Job]: A dictionary of all jobs, with job IDs as keys and Job objects as values
+        """
+        pass

--- a/remote_vector_index_builder/app/storage/memory.py
+++ b/remote_vector_index_builder/app/storage/memory.py
@@ -157,3 +157,13 @@ class InMemoryRequestStore(RequestStore):
         while True:
             time.sleep(5)  # Run cleanup every 5 seconds
             self.cleanup_expired()
+
+    def get_jobs(self) -> Dict[str, Job]:
+        """
+        Retrieve all jobs from the store.
+
+        Returns:
+            Dict[str, Job]: A dictionary of all jobs, with job IDs as keys and Job objects as values
+        """
+        with self._lock:
+            return {job_id: job for job_id, (job, _) in self._store.items()}

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ exclude =
     __pycache__,
     remote_vector_index_builder/core/test_imports.py
     remote_vector_index_builder/app/test_imports.py
+    e2e/api/test_imports.py
 
 # Output formatting
 statistics = True

--- a/test_remote_vector_index_builder/test_app/test_routes/test_get_jobs.py
+++ b/test_remote_vector_index_builder/test_app/test_routes/test_get_jobs.py
@@ -1,0 +1,116 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import pytest
+import json
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import Mock
+from app.routes import get_jobs
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(get_jobs.router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_job_service():
+    return Mock()
+
+
+class JobMock:
+    """Mock job class for testing"""
+
+    def __init__(self, job_id, status, file_name=None, error_message=None):
+        self.job_id = job_id
+        self.status = status
+        self.file_name = file_name
+        self.error_message = error_message
+
+
+def test_get_jobs_basic(client, mock_job_service):
+    """Test basic retrieval of jobs"""
+    # Arrange
+    app = client.app
+    app.state.job_service = mock_job_service
+    job_id = "test-job-1"
+    mock_job = JobMock(job_id, "RUNNING_INDEX_BUILD", "test_file.index")
+    mock_job_service.get_jobs.return_value = {job_id: mock_job}
+
+    response = client.get("/_jobs")
+
+    assert response.status_code == 200
+    response_data = response.json()
+    response_data = json.loads(response_data)
+    assert isinstance(response_data, dict)
+    assert len(response_data) == 1
+    assert job_id in response_data
+    assert response_data[job_id]["job_id"] == job_id
+    assert response_data[job_id]["status"] == "RUNNING_INDEX_BUILD"
+    assert response_data[job_id]["file_name"] == "test_file.index"
+    mock_job_service.get_jobs.assert_called_once()
+
+
+def test_get_multiple_jobs(client, mock_job_service):
+    """Test retrieval of multiple jobs"""
+    # Arrange
+    app = client.app
+    app.state.job_service = mock_job_service
+
+    job1_id = "test-job-1"
+    job2_id = "test-job-2"
+    job3_id = "test-job-3"
+
+    job1 = JobMock(job1_id, "RUNNING_INDEX_BUILD", "file1.index")
+    job2 = JobMock(job2_id, "COMPLETED", "file2.index")
+    job3 = JobMock(job3_id, "FAILED", None, "Error occurred")
+
+    mock_job_service.get_jobs.return_value = {
+        job1_id: job1,
+        job2_id: job2,
+        job3_id: job3,
+    }
+
+    response = client.get("/_jobs")
+
+    assert response.status_code == 200
+    response_data = response.json()
+    response_data = json.loads(response_data)
+    assert isinstance(response_data, dict)
+    assert len(response_data) == 3
+    assert job1_id in response_data
+    assert job2_id in response_data
+    assert job3_id in response_data
+    assert response_data[job1_id]["job_id"] == job1_id
+    assert response_data[job2_id]["job_id"] == job2_id
+    assert response_data[job3_id]["job_id"] == job3_id
+    mock_job_service.get_jobs.assert_called_once()
+
+
+def test_get_empty_jobs_list(client, mock_job_service):
+    """Test retrieval when there are no jobs"""
+
+    app = client.app
+    app.state.job_service = mock_job_service
+    mock_job_service.get_jobs.return_value = {}
+
+    response = client.get("/_jobs")
+
+    assert response.status_code == 200
+    response_data = response.json()
+    response_data = json.loads(response_data)
+    assert isinstance(response_data, dict)
+    assert len(response_data) == 0
+    mock_job_service.get_jobs.assert_called_once()

--- a/test_remote_vector_index_builder/test_app/test_routes/test_heart_beat.py
+++ b/test_remote_vector_index_builder/test_app/test_routes/test_heart_beat.py
@@ -1,0 +1,27 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from app.routes import heart_beat
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(heart_beat.router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def test_heart_beat(client):
+    response = client.get("/_heart_beat")
+    assert response.status_code == 200

--- a/test_remote_vector_index_builder/test_app/test_services/test_job_service.py
+++ b/test_remote_vector_index_builder/test_app/test_services/test_job_service.py
@@ -174,3 +174,23 @@ def test_get_job_not_exists(job_service):
     """Test retrieving non-existent job"""
     result = job_service.get_job("test_id")
     assert result is None
+
+
+def test_get_jobs(job_service):
+    """Test get all jobs"""
+
+    mock_job_1 = Mock(spec=Job)
+    mock_job_2 = Mock(spec=Job)
+
+    job_service.request_store.get_jobs.return_value = {
+        "test_id1": mock_job_1,
+        "test_id2": mock_job_2,
+    }
+
+    jobs = job_service.get_jobs()
+
+    assert "test_id1" in jobs
+    assert "test_id2" in jobs
+    assert len(jobs) == 2
+    assert jobs["test_id1"] == mock_job_1
+    assert jobs["test_id2"] == mock_job_2

--- a/test_remote_vector_index_builder/test_app/test_storage/test_memory.py
+++ b/test_remote_vector_index_builder/test_app/test_storage/test_memory.py
@@ -136,3 +136,13 @@ def test_get_no_ttl(settings_no_ttl, sample_job):
     store.add("job1", sample_job)
     time.sleep(1.1)  # Even after waiting, job should still be there
     assert store.get("job1") == sample_job
+
+
+def test_get_jobs(settings, sample_job):
+    store = InMemoryRequestStore(settings)
+    store.add("job1", sample_job)
+    store.add("job2", sample_job)
+    jobs = store.get_jobs()
+    assert len(jobs) == 2
+    assert jobs["job1"] == sample_job
+    assert jobs["job2"] == sample_job


### PR DESCRIPTION
### Description
Add `_jobs` and `_heart_beat` APIs for coordinator stack. This allows the worker to be used with the coordinator code here: https://github.com/navneet1v/VectorSearchForge/tree/main/remote-index-build-service/coordinator

I also added formatting checks to the e2e folder, so there are a couple of formatting related changes in this PR as well. The `_jobs` and `_heart_beat` APIs are integrated with the e2e IT. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).