### PR TITLE
Allocate memory in Workflow Executor

### DIFF
--- a/e2e/api/docker-compose.yml
+++ b/e2e/api/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-1
+      - GPU_MEMORY_LIMIT=2
+      - CPU_MEMORY_LIMIT=6
     ports:
       - "8080:1025"
 

--- a/e2e/api/docker-compose.yml
+++ b/e2e/api/docker-compose.yml
@@ -25,8 +25,6 @@ services:
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-1
-      - GPU_MEMORY_LIMIT=2
-      - CPU_MEMORY_LIMIT=7
     ports:
       - "8080:1025"
 

--- a/e2e/api/docker-compose.yml
+++ b/e2e/api/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-1
       - GPU_MEMORY_LIMIT=2
-      - CPU_MEMORY_LIMIT=6
+      - CPU_MEMORY_LIMIT=7
     ports:
       - "8080:1025"
 

--- a/e2e/api/run_e2e.py
+++ b/e2e/api/run_e2e.py
@@ -5,9 +5,9 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
 import logging
-import json
 import time
 import sys
 import os
@@ -26,6 +26,78 @@ def run_e2e_index_builder(config_path: str = "api/test-datasets.yml"):
     logger = logging.getLogger(__name__)
     dataset_generator = VectorDatasetGenerator(config_path)
 
+    def process_dataset(dataset_name):
+        """Process a single dataset in parallel."""
+        logger.info(f"\n=== Processing dataset: {dataset_name} ===")
+
+        try:
+            gen_and_upload_metrics = dataset_generator.generate_and_upload_dataset(
+                dataset_name
+            )
+
+            dataset_config = dataset_generator.config["datasets"][dataset_name]
+            s3_config = dataset_generator.config["storage"]["s3"]
+
+            index_build_params = {
+                "vector_path": s3_config["paths"]["vectors"].format(
+                    dataset_name=dataset_name
+                ),
+                "doc_id_path": s3_config["paths"]["doc_ids"].format(
+                    dataset_name=dataset_name
+                ),
+                "container_name": bucket,
+                "dimension": dataset_config["dimension"],
+                "doc_count": dataset_config["num_vectors"],
+                "data_type": DataType.FLOAT,
+                "repository_type": ObjectStoreType.S3,
+                "engine": Engine.FAISS,
+            }
+
+            logger.info(f"Running vector index builder workflow for {dataset_name}...")
+
+            client = RemoteVectorAPIClient(http_request_timeout=30)
+
+            start_time = time.time()
+            # Submit job
+            job_id = client.build_index(index_build_params)
+            logger.info(f"Created job: {job_id} for dataset: {dataset_name}")
+
+            # Wait for completion (20 minute timeout)
+            result = client.wait_for_job_completion(
+                job_id,
+                status_request_timeout=1200,  # 20 minutes
+                interval=10,  # Check every 10 seconds
+            )
+            run_tasks_total_time = time.time() - start_time
+
+            if result.task_status != JobStatus.COMPLETED:
+                logger.error(f"Error in workflow for {dataset_name}: {result.error_message}")
+                raise RuntimeError(f"Job failed for {dataset_name}: {result.error_message}")
+
+            vector_dataset_name = ".".join(
+                os.path.basename(index_build_params["vector_path"]).split(".")[0:-1]
+            )
+            index_file_name = (
+                    vector_dataset_name + "." + index_build_params["engine"]
+            )
+            if result.file_name != index_file_name:
+                error_msg = f"Error in workflow for {dataset_name}: Vector file upload path mismatch, expected:{index_file_name}, got: {result.file_name}"
+                logger.error(error_msg)
+                raise RuntimeError(f"Job Failed for {dataset_name}: {error_msg}")
+
+            logger.info(f"Successfully processed dataset: {dataset_name}")
+            metrics = {
+                "dataset": gen_and_upload_metrics,
+                "run_tasks_total_time": run_tasks_total_time,
+            }
+            logger.info(f"Metrics for {dataset_name}: {metrics}")
+            return dataset_name, True, metrics
+        except Exception as e:
+            logger.exception(f"Error processing dataset {dataset_name}: {str(e)}")
+            return dataset_name, False, str(e)
+
+    bucket = None
+    s3_client = None
     try:
         # Create test bucket if it doesn't exist
         s3_client = dataset_generator.object_store.s3_client
@@ -36,91 +108,39 @@ def run_e2e_index_builder(config_path: str = "api/test-datasets.yml"):
         except s3_client.exceptions.BucketAlreadyExists:
             logger.info(f"Using existing bucket: {bucket}")
 
-        # Process each dataset
-        for dataset_name in dataset_generator.config["datasets"]:
-            logger.info(f"\n=== Processing dataset: {dataset_name} ===")
+        # Process datasets in parallel
+        all_metrics = {}
+        total_start_time = time.time()
 
-            try:
-                gen_and_upload_metrics = dataset_generator.generate_and_upload_dataset(
-                    dataset_name
-                )
+        with ThreadPoolExecutor() as executor:
+            # Submit all dataset processing tasks to the executor
+            future_to_dataset = {
+                executor.submit(process_dataset, dataset_name): dataset_name
+                for dataset_name in dataset_generator.config["datasets"]
+            }
 
-                dataset_config = dataset_generator.config["datasets"][dataset_name]
-                s3_config = dataset_generator.config["storage"]["s3"]
+            # Process results as they complete
+            all_succeeded = True
+            for future in as_completed(future_to_dataset):
+                dataset_name = future_to_dataset[future]
+                try:
+                    ds_name, success, result = future.result()
+                    if success:
+                        all_metrics[ds_name] = result
+                    else:
+                        all_succeeded = False
+                        logger.error(f"Dataset {ds_name} failed: {result}")
+                except Exception as e:
+                    all_succeeded = False
+                    logger.exception(f"Exception processing dataset {dataset_name}: {str(e)}")
 
-                index_build_params = {
-                    "vector_path": s3_config["paths"]["vectors"].format(
-                        dataset_name=dataset_name
-                    ),
-                    "doc_id_path": s3_config["paths"]["doc_ids"].format(
-                        dataset_name=dataset_name
-                    ),
-                    "container_name": bucket,
-                    "dimension": dataset_config["dimension"],
-                    "doc_count": dataset_config["num_vectors"],
-                    "data_type": DataType.FLOAT,
-                    "repository_type": ObjectStoreType.S3,
-                    "engine": Engine.FAISS,
-                }
+        total_execution_time = time.time() - total_start_time
+        logger.info(f"Total parallel execution time: {total_execution_time:.2f}s")
 
-                logger.info("\nRunning vector index builder workflow...")
+        if not all_succeeded:
+            raise RuntimeError("One or more datasets failed to process.")
 
-                client = RemoteVectorAPIClient(http_request_timeout=30)
-
-                client.heart_beat()
-
-                start_time = time.time()
-                # Submit job
-                job_id = client.build_index(index_build_params)
-                logger.info(f"Created job: {job_id}")
-
-                jobs = json.loads(client.get_jobs())
-                logger.info(f"Jobs: {jobs}")
-                if job_id not in jobs:
-                    logger.error(f"Error in workflow: Job {job_id} not found")
-                    raise RuntimeError("Job not found")
-
-                # Wait for completion (20 minute timeout)
-                result = client.wait_for_job_completion(
-                    job_id,
-                    status_request_timeout=1200,  # 20 minutes
-                    interval=10,  # Check every 10 seconds
-                )
-                run_tasks_total_time = time.time() - start_time
-
-                if result.task_status != JobStatus.COMPLETED:
-                    logger.error(f"Error in workflow: {result.error_message}")
-                    raise RuntimeError(f"Job failed: {result.error_message}")
-
-                vector_dataset_name = ".".join(
-                    os.path.basename(index_build_params["vector_path"]).split(".")[0:-1]
-                )
-                index_file_name = (
-                    vector_dataset_name + "." + index_build_params["engine"]
-                )
-                if result.file_name != index_file_name:
-                    error_msg = (
-                        f"Error in workflow: Vector file upload path mismatch, "
-                        f"expected:{index_file_name}, got: {result.file_name}"
-                    )
-                    logger.error(error_msg)
-                    raise RuntimeError(f"Job Failed: {error_msg}")
-
-                logger.info(f"Successfully processed dataset: {dataset_name}")
-                metrics = {
-                    "dataset": gen_and_upload_metrics,
-                    "run_tasks_total_time": run_tasks_total_time,
-                }
-                logger.info(metrics)
-
-            except Exception as e:
-                logger.exception(f"Error processing dataset {dataset_name}: {str(e)}")
-                raise
-
-        jobs = json.loads(client.get_jobs())
-        if len(jobs) != len(dataset_generator.config["datasets"]):
-            logger.error("Error in workflow: Not all jobs found")
-            raise RuntimeError("Not all jobs found")
+        logger.info(f"All datasets processed successfully.")
 
     except Exception as e:
         logger.error(f"E2E test failed: {str(e)}")

--- a/e2e/api/run_e2e.py
+++ b/e2e/api/run_e2e.py
@@ -78,17 +78,23 @@ def run_e2e_index_builder(config_path: str = "api/test-datasets.yml"):
             run_tasks_total_time = time.time() - start_time
 
             if result.task_status != JobStatus.COMPLETED:
-                logger.error(f"Error in workflow for {dataset_name}: {result.error_message}")
-                raise RuntimeError(f"Job failed for {dataset_name}: {result.error_message}")
+                logger.error(
+                    f"Error in workflow for {dataset_name}: {result.error_message}"
+                )
+                raise RuntimeError(
+                    f"Job failed for {dataset_name}: {result.error_message}"
+                )
 
             vector_dataset_name = ".".join(
                 os.path.basename(index_build_params["vector_path"]).split(".")[0:-1]
             )
-            index_file_name = (
-                    vector_dataset_name + "." + index_build_params["engine"]
-            )
+            index_file_name = vector_dataset_name + "." + index_build_params["engine"]
             if result.file_name != index_file_name:
-                error_msg = f"Error in workflow for {dataset_name}: Vector file upload path mismatch, expected:{index_file_name}, got: {result.file_name}"
+                error_msg = (
+                    f"Error in workflow for {dataset_name}: "
+                    f"Vector file upload path mismatch, "
+                    f"expected:{index_file_name}, got: {result.file_name}"
+                )
                 logger.error(error_msg)
                 raise RuntimeError(f"Job Failed for {dataset_name}: {error_msg}")
 
@@ -104,7 +110,6 @@ def run_e2e_index_builder(config_path: str = "api/test-datasets.yml"):
             return dataset_name, False, str(e)
 
     bucket = None
-    s3_client = None
     client = RemoteVectorAPIClient(http_request_timeout=30)
     try:
         # Create test bucket if it doesn't exist
@@ -140,7 +145,9 @@ def run_e2e_index_builder(config_path: str = "api/test-datasets.yml"):
                         logger.error(f"Dataset {ds_name} failed: {result}")
                 except Exception as e:
                     all_succeeded = False
-                    logger.exception(f"Exception processing dataset {dataset_name}: {str(e)}")
+                    logger.exception(
+                        f"Exception processing dataset {dataset_name}: {str(e)}"
+                    )
 
         total_execution_time = time.time() - total_start_time
         logger.info(f"Total parallel execution time: {total_execution_time:.2f}s")
@@ -152,7 +159,7 @@ def run_e2e_index_builder(config_path: str = "api/test-datasets.yml"):
             logger.error("Error in workflow: Not all jobs found")
             raise RuntimeError("Not all jobs found")
 
-        logger.info(f"All datasets processed successfully.")
+        logger.info("All datasets processed successfully.")
 
     except Exception as e:
         logger.error(f"E2E test failed: {str(e)}")

--- a/remote_vector_index_builder/app/base/config.py
+++ b/remote_vector_index_builder/app/base/config.py
@@ -23,9 +23,7 @@ class Settings(BaseSettings):
     )
 
     # In memory settings
-    request_store_max_size: int = int(
-        os.environ.get("REQUEST_STORE_MAX_SIZE", "1000000")
-    )
+    request_store_max_size: int = int(os.environ.get("REQUEST_STORE_MAX_SIZE", "10000"))
     request_store_ttl_seconds: Optional[int] = int(
         os.environ.get("REQUEST_STORE_TTL_SECONDS", "1800")
     )

--- a/remote_vector_index_builder/app/base/config.py
+++ b/remote_vector_index_builder/app/base/config.py
@@ -8,6 +8,7 @@
 from pydantic_settings import BaseSettings
 from app.storage.types import RequestStoreType
 from typing import Optional
+import os
 
 
 class Settings(BaseSettings):
@@ -17,19 +18,26 @@ class Settings(BaseSettings):
     """
 
     # Request Store settings
-    request_store_type: RequestStoreType = RequestStoreType.MEMORY
+    request_store_type: RequestStoreType = os.environ.get(
+        "REQUEST_STORE_TYPE", RequestStoreType.MEMORY
+    )
 
     # In memory settings
-    request_store_max_size: int = 1000000
-    request_store_ttl_seconds: Optional[int] = 600
+    request_store_max_size: int = int(
+        os.environ.get("REQUEST_STORE_MAX_SIZE", "1000000")
+    )
+    request_store_ttl_seconds: Optional[int] = int(
+        os.environ.get("REQUEST_STORE_TTL_SECONDS", "1800")
+    )
 
-    # Resource Manager settings, in bytes
-    gpu_memory_limit: float = 24.0 * 10**9
-    cpu_memory_limit: float = 32.0 * 10**9
+    # Resource Manager settings, in GB
+    # Value later gets multiplied by 10**9
+    gpu_memory_limit: float = float(os.environ.get("GPU_MEMORY_LIMIT", "24.0"))
+    cpu_memory_limit: float = float(os.environ.get("CPU_MEMORY_LIMIT", "32.0"))
 
     # Workflow Executor settings
-    max_workers: int = 5
+    max_workers: int = int(os.environ.get("MAX_WORKERS", "2"))
 
     # Service settings
     service_name: str = "remote-vector-index-builder-api"
-    log_level: str = "INFO"
+    log_level: str = os.environ.get("LOG_LEVEL", "INFO")

--- a/remote_vector_index_builder/app/executors/workflow_executor.py
+++ b/remote_vector_index_builder/app/executors/workflow_executor.py
@@ -92,7 +92,7 @@ class WorkflowExecutor:
         ):
             self._request_store.update(
                 workflow.job_id,
-                {"status": JobStatus.FAILED, "error_message": "Worker has no memory"},
+                {"status": JobStatus.FAILED, "error_message": "Worker has not enough memory available at this time"},
             )
             return
 

--- a/remote_vector_index_builder/app/executors/workflow_executor.py
+++ b/remote_vector_index_builder/app/executors/workflow_executor.py
@@ -86,6 +86,7 @@ class WorkflowExecutor:
             This method is intended to be run in a separate thread.
         """
 
+        # TODO: Block until memory resource is available, instead of failing immediately
         if not self._resource_manager.allocate(
             workflow.gpu_memory_required, workflow.cpu_memory_required
         ):

--- a/remote_vector_index_builder/app/executors/workflow_executor.py
+++ b/remote_vector_index_builder/app/executors/workflow_executor.py
@@ -12,6 +12,7 @@ from app.models.workflow import BuildWorkflow
 from app.base.resources import ResourceManager
 from app.storage.base import RequestStore
 from app.models.job import JobStatus
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -85,15 +86,28 @@ class WorkflowExecutor:
         Note:
             This method is intended to be run in a separate thread.
         """
+        resources_allocated = False
         try:
             logger.info(f"Starting execution of job {workflow.job_id}")
+            # sleep to give other waiting job threads the chance to allocate resources
+            time.sleep(2)
 
-            # Job may have been deleted by request store TTL
-            if not self._request_store.get(workflow.job_id):
-                logger.info(f"Job {workflow.job_id} was deleted before execution")
-                return
+            while not self._resource_manager.allocate(
+                workflow.gpu_memory_required, workflow.cpu_memory_required
+            ):
+                # Job may have been deleted by request store TTL
+                if not self._request_store.get(workflow.job_id):
+                    logger.info(f"Job {workflow.job_id} was deleted before execution")
+                    return
 
-            # Execute the build
+                time.sleep(0.1)
+
+            logger.info(
+                f"Worker resource status after allocating memory for job id {workflow.job_id}: - "
+                f"GPU: {self._resource_manager.get_available_gpu_memory():,} bytes, "
+                f"CPU: {self._resource_manager.get_available_cpu_memory():,} bytes"
+            )
+            resources_allocated = True
             success, index_path, msg = self._build_index_fn(workflow)
 
             # Job may have been deleted by request store TTL, so we need to check if job
@@ -122,9 +136,10 @@ class WorkflowExecutor:
             )
         finally:
             # Release resources
-            self._resource_manager.release(
-                workflow.gpu_memory_required, workflow.cpu_memory_required
-            )
+            if resources_allocated:
+                self._resource_manager.release(
+                    workflow.gpu_memory_required, workflow.cpu_memory_required
+                )
 
     def shutdown(self) -> None:
         """

--- a/remote_vector_index_builder/app/executors/workflow_executor.py
+++ b/remote_vector_index_builder/app/executors/workflow_executor.py
@@ -92,7 +92,10 @@ class WorkflowExecutor:
         ):
             self._request_store.update(
                 workflow.job_id,
-                {"status": JobStatus.FAILED, "error_message": "Worker has not enough memory available at this time"},
+                {
+                    "status": JobStatus.FAILED,
+                    "error_message": "Worker has not enough memory available at this time",
+                },
             )
             return
 

--- a/remote_vector_index_builder/app/main.py
+++ b/remote_vector_index_builder/app/main.py
@@ -54,6 +54,8 @@ from app.utils.error_message import get_field_path
 import logging
 
 settings = Settings()
+gpu_memory_limit = settings.gpu_memory_limit * 10**9
+cpu_memory_limit = settings.cpu_memory_limit * 10**9
 
 configure_logging(settings.log_level)
 
@@ -64,8 +66,8 @@ request_store = RequestStoreFactory.create(
 )
 
 resource_manager = ResourceManager(
-    total_gpu_memory=settings.gpu_memory_limit,
-    total_cpu_memory=settings.cpu_memory_limit,
+    total_gpu_memory=gpu_memory_limit,
+    total_cpu_memory=cpu_memory_limit,
 )
 
 index_builder = IndexBuilder()
@@ -79,10 +81,9 @@ workflow_executor = WorkflowExecutor(
 
 job_service = JobService(
     request_store=request_store,
-    resource_manager=resource_manager,
     workflow_executor=workflow_executor,
-    total_gpu_memory=settings.gpu_memory_limit,
-    total_cpu_memory=settings.cpu_memory_limit,
+    total_gpu_memory=gpu_memory_limit,
+    total_cpu_memory=cpu_memory_limit,
 )
 
 app = FastAPI(title=settings.service_name)

--- a/remote_vector_index_builder/app/services/job_service.py
+++ b/remote_vector_index_builder/app/services/job_service.py
@@ -181,10 +181,6 @@ class JobService:
         logger.info(
             f"Job id requirements: GPU memory: {gpu_mem}, CPU memory: {cpu_mem}"
         )
-        logger.info(
-            f"Total memory available: GPU: {self.total_gpu_memory},"
-            f" CPU: {self.total_cpu_memory}"
-        )
 
         workflow = self._create_workflow(
             job_id, gpu_mem, cpu_mem, index_build_parameters

--- a/remote_vector_index_builder/app/utils/memory.py
+++ b/remote_vector_index_builder/app/utils/memory.py
@@ -6,6 +6,10 @@
 # compatible open source license.
 from core.common.models import IndexBuildParameters
 
+EDGE_SIZE = 8
+MEMORY_OVERHEAD_FACTOR = 1.1
+GPU_SCALING_FACTOR = 0.5
+
 
 def calculate_memory_requirements(
     index_build_parameters: IndexBuildParameters,
@@ -41,9 +45,15 @@ def calculate_memory_requirements(
 
     # use formula to calculate memory taken up by index
     index_gpu_memory = (
-        (vector_dimensions * entry_size + m * 8) * 1.1 * num_vectors
-    ) * 0.5
+        (vector_dimensions * entry_size + m * EDGE_SIZE)
+        * MEMORY_OVERHEAD_FACTOR
+        * num_vectors
+    ) * GPU_SCALING_FACTOR
 
-    index_cpu_memory = (vector_dimensions * entry_size + m * 8) * 1.1 * num_vectors
+    index_cpu_memory = (
+        (vector_dimensions * entry_size + m * EDGE_SIZE)
+        * MEMORY_OVERHEAD_FACTOR
+        * num_vectors
+    )
 
     return index_gpu_memory, (index_cpu_memory + vector_memory)

--- a/remote_vector_index_builder/app/utils/memory.py
+++ b/remote_vector_index_builder/app/utils/memory.py
@@ -42,8 +42,8 @@ def calculate_memory_requirements(
     # use formula to calculate memory taken up by index
     index_gpu_memory = (
         (vector_dimensions * entry_size + m * 8) * 1.1 * num_vectors
-    ) * 1.5
+    ) * 0.5
 
     index_cpu_memory = (vector_dimensions * entry_size + m * 8) * 1.1 * num_vectors
 
-    return (index_gpu_memory + vector_memory), (index_cpu_memory + vector_memory)
+    return index_gpu_memory, (index_cpu_memory + vector_memory)

--- a/test_remote_vector_index_builder/test_app/test_executors/test_workflow_executor.py
+++ b/test_remote_vector_index_builder/test_app/test_executors/test_workflow_executor.py
@@ -85,28 +85,27 @@ def test_successful_workflow_execution(
     mock_build_index_fn,
 ):
     """Test successful execution of a workflow"""
-    with patch("time.sleep"):
-        mock_build_index_fn.return_value = (True, "/path/to/index", None)
+    mock_build_index_fn.return_value = (True, "/path/to/index", None)
 
-        mock_resource_manager.allocate.return_value = True
+    mock_resource_manager.allocate.return_value = True
 
-        workflow_executor.submit_workflow(sample_workflow_1)
-        workflow_executor._executor.shutdown(wait=True)
+    workflow_executor.submit_workflow(sample_workflow_1)
+    workflow_executor._executor.shutdown(wait=True)
 
-        mock_build_index_fn.assert_called_once_with(sample_workflow_1)
+    mock_build_index_fn.assert_called_once_with(sample_workflow_1)
 
-        mock_request_store.update.assert_called_with(
-            sample_workflow_1.job_id,
-            {
-                "status": JobStatus.COMPLETED,
-                "file_name": "/path/to/index",
-                "error_message": None,
-            },
-        )
+    mock_request_store.update.assert_called_with(
+        sample_workflow_1.job_id,
+        {
+            "status": JobStatus.COMPLETED,
+            "file_name": "/path/to/index",
+            "error_message": None,
+        },
+    )
 
-        mock_resource_manager.release.assert_called_with(
-            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
-        )
+    mock_resource_manager.release.assert_called_with(
+        sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+    )
 
 
 def test_failed_workflow_execution(
@@ -117,29 +116,28 @@ def test_failed_workflow_execution(
     mock_build_index_fn,
 ):
     """Test workflow execution with failure"""
-    with patch("time.sleep"):
-        error_message = "Build failed"
-        mock_build_index_fn.return_value = (False, None, error_message)
+    error_message = "Build failed"
+    mock_build_index_fn.return_value = (False, None, error_message)
 
-        mock_resource_manager.allocate.return_value = True
+    mock_resource_manager.allocate.return_value = True
 
-        workflow_executor.submit_workflow(sample_workflow_1)
-        workflow_executor._executor.shutdown(wait=True)
+    workflow_executor.submit_workflow(sample_workflow_1)
+    workflow_executor._executor.shutdown(wait=True)
 
-        mock_build_index_fn.assert_called_once_with(sample_workflow_1)
+    mock_build_index_fn.assert_called_once_with(sample_workflow_1)
 
-        mock_request_store.update.assert_called_with(
-            sample_workflow_1.job_id,
-            {
-                "status": JobStatus.FAILED,
-                "file_name": None,
-                "error_message": error_message,
-            },
-        )
+    mock_request_store.update.assert_called_with(
+        sample_workflow_1.job_id,
+        {
+            "status": JobStatus.FAILED,
+            "file_name": None,
+            "error_message": error_message,
+        },
+    )
 
-        mock_resource_manager.release.assert_called_with(
-            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
-        )
+    mock_resource_manager.release.assert_called_with(
+        sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+    )
 
 
 def test_deleted_job_during_execution(
@@ -151,20 +149,19 @@ def test_deleted_job_during_execution(
 ):
     """Test handling of job that was deleted during execution"""
 
-    with patch("time.sleep"):
-        mock_resource_manager.allocate.return_value = True
-        mock_request_store.get.return_value = False
+    mock_resource_manager.allocate.return_value = True
+    mock_request_store.get.return_value = False
 
-        workflow_executor.submit_workflow(sample_workflow_1)
-        workflow_executor._executor.shutdown(wait=True)
+    workflow_executor.submit_workflow(sample_workflow_1)
+    workflow_executor._executor.shutdown(wait=True)
 
-        mock_build_index_fn.assert_called_once()
-        mock_request_store.update.assert_not_called()
+    mock_build_index_fn.assert_called_once()
+    mock_request_store.update.assert_not_called()
 
-        mock_build_index_fn.assert_called_once()
-        mock_resource_manager.release.assert_called_with(
-            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
-        )
+    mock_build_index_fn.assert_called_once()
+    mock_resource_manager.release.assert_called_with(
+        sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+    )
 
 
 def test_exception_during_execution(
@@ -175,27 +172,26 @@ def test_exception_during_execution(
     mock_build_index_fn,
 ):
     """Test handling of exceptions during execution"""
-    with patch("time.sleep"):
-        error_message = "Unexpected error"
-        mock_build_index_fn.side_effect = Exception(error_message)
+    error_message = "Unexpected error"
+    mock_build_index_fn.side_effect = Exception(error_message)
 
-        mock_resource_manager.allocate.return_value = True
+    mock_resource_manager.allocate.return_value = True
 
-        workflow_executor.submit_workflow(sample_workflow_1)
-        workflow_executor._executor.shutdown(wait=True)
+    workflow_executor.submit_workflow(sample_workflow_1)
+    workflow_executor._executor.shutdown(wait=True)
 
-        mock_request_store.update.assert_called_with(
-            sample_workflow_1.job_id,
-            {"status": JobStatus.FAILED, "error_message": error_message},
-        )
-        mock_build_index_fn.assert_called_once()
+    mock_request_store.update.assert_called_with(
+        sample_workflow_1.job_id,
+        {"status": JobStatus.FAILED, "error_message": error_message},
+    )
+    mock_build_index_fn.assert_called_once()
 
-        mock_resource_manager.release.assert_called_with(
-            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
-        )
+    mock_resource_manager.release.assert_called_with(
+        sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+    )
 
 
-def test_not_enough_memory_initially_successful_execution(
+def test_not_enough_memory(
     workflow_executor,
     sample_workflow_1,
     mock_request_store,
@@ -203,53 +199,24 @@ def test_not_enough_memory_initially_successful_execution(
     mock_build_index_fn,
 ):
     """
-    Test successful execution when there is not enough initial memory for the workflow
+    Test handling when there is not enough memory for the workflow
     """
 
-    with patch("time.sleep") as patched_sleep:
-        mock_resource_manager.allocate.side_effect = (False, True)
+    mock_resource_manager.allocate.return_value = False
 
-        mock_build_index_fn.return_value = (True, "/path/to/index", None)
+    workflow_executor.submit_workflow(sample_workflow_1)
+    workflow_executor._executor.shutdown(wait=True)
 
-        workflow_executor.submit_workflow(sample_workflow_1)
-        workflow_executor._executor.shutdown(wait=True)
+    mock_build_index_fn.assert_not_called()
+    mock_resource_manager.release.assert_not_called()
 
-        mock_build_index_fn.assert_called_once_with(sample_workflow_1)
-        assert patched_sleep.call_count == 2
-
-        mock_request_store.update.assert_called_with(
-            sample_workflow_1.job_id,
-            {
-                "status": JobStatus.COMPLETED,
-                "file_name": "/path/to/index",
-                "error_message": None,
-            },
-        )
-
-        mock_resource_manager.release.assert_called_with(
-            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
-        )
-
-
-def test_not_enough_memory_initially_deleted_job(
-    workflow_executor,
-    sample_workflow_1,
-    mock_request_store,
-    mock_resource_manager,
-    mock_build_index_fn,
-):
-    """Test handling of job that was deleted during the memory allocation check"""
-
-    with patch("time.sleep") as patched_sleep:
-        mock_resource_manager.allocate.return_value = False
-        mock_request_store.get.return_value = False
-
-        workflow_executor.submit_workflow(sample_workflow_1)
-        workflow_executor._executor.shutdown(wait=True)
-
-        assert patched_sleep.call_count == 1
-        mock_build_index_fn.assert_not_called()
-        mock_resource_manager.release.assert_not_called()
+    mock_request_store.update.assert_called_with(
+        sample_workflow_1.job_id,
+        {
+            "status": JobStatus.FAILED,
+            "error_message": "Worker has no memory",
+        },
+    )
 
 
 def test_shutdown(workflow_executor):

--- a/test_remote_vector_index_builder/test_app/test_executors/test_workflow_executor.py
+++ b/test_remote_vector_index_builder/test_app/test_executors/test_workflow_executor.py
@@ -214,7 +214,7 @@ def test_not_enough_memory(
         sample_workflow_1.job_id,
         {
             "status": JobStatus.FAILED,
-            "error_message": "Worker has no memory",
+            "error_message": "Worker has not enough memory available at this time",
         },
     )
 

--- a/test_remote_vector_index_builder/test_app/test_executors/test_workflow_executor.py
+++ b/test_remote_vector_index_builder/test_app/test_executors/test_workflow_executor.py
@@ -9,19 +9,31 @@ from unittest.mock import Mock, patch
 from concurrent.futures import ThreadPoolExecutor
 from app.models.workflow import BuildWorkflow
 from app.models.job import JobStatus
+from app.base.resources import ResourceManager
 from app.executors.workflow_executor import WorkflowExecutor
+
+TOTAL_GPU_MEMORY = 10
+TOTAL_CPU_MEMORY = 10
 
 
 @pytest.fixture
 def mock_request_store():
     store = Mock()
-    store.get.return_value = True  # Default to existing job
+    store.get.return_value = True
     return store
 
 
 @pytest.fixture
 def mock_resource_manager():
-    return Mock()
+    rm = Mock(
+        spec=ResourceManager,
+        total_gpu_memory=TOTAL_GPU_MEMORY,
+        total_cpu_memory=TOTAL_CPU_MEMORY,
+    )
+    # actual values here doesn't matter for the unit tests
+    rm.get_available_gpu_memory.return_value = -1
+    rm.get_available_cpu_memory.return_value = -1
+    return rm
 
 
 @pytest.fixture
@@ -40,11 +52,11 @@ def workflow_executor(mock_request_store, mock_resource_manager, mock_build_inde
 
 
 @pytest.fixture
-def sample_workflow():
+def sample_workflow_1():
     workflow = Mock(spec=BuildWorkflow)
-    workflow.job_id = "test_job_123"
-    workflow.gpu_memory_required = 1000
-    workflow.cpu_memory_required = 2000
+    workflow.job_id = "test_job_1"
+    workflow.gpu_memory_required = TOTAL_GPU_MEMORY - 2
+    workflow.cpu_memory_required = TOTAL_CPU_MEMORY - 6
     return workflow
 
 
@@ -67,117 +79,177 @@ def test_workflow_executor_initialization(
 
 def test_successful_workflow_execution(
     workflow_executor,
-    sample_workflow,
+    sample_workflow_1,
     mock_request_store,
     mock_resource_manager,
     mock_build_index_fn,
 ):
     """Test successful execution of a workflow"""
-    mock_build_index_fn.return_value = (True, "/path/to/index", None)
+    with patch("time.sleep"):
+        mock_build_index_fn.return_value = (True, "/path/to/index", None)
 
-    # Execute workflow
-    workflow_executor.submit_workflow(sample_workflow)
-    # Wait for execution to complete
-    workflow_executor._executor.shutdown(wait=True)
+        mock_resource_manager.allocate.return_value = True
 
-    # Verify build function was called
-    mock_build_index_fn.assert_called_once_with(sample_workflow)
+        workflow_executor.submit_workflow(sample_workflow_1)
+        workflow_executor._executor.shutdown(wait=True)
 
-    # Verify status update
-    mock_request_store.update.assert_called_with(
-        sample_workflow.job_id,
-        {
-            "status": JobStatus.COMPLETED,
-            "file_name": "/path/to/index",
-            "error_message": None,
-        },
-    )
+        mock_build_index_fn.assert_called_once_with(sample_workflow_1)
 
-    # Verify resource release
-    mock_resource_manager.release.assert_called_with(
-        sample_workflow.gpu_memory_required, sample_workflow.cpu_memory_required
-    )
+        mock_request_store.update.assert_called_with(
+            sample_workflow_1.job_id,
+            {
+                "status": JobStatus.COMPLETED,
+                "file_name": "/path/to/index",
+                "error_message": None,
+            },
+        )
+
+        mock_resource_manager.release.assert_called_with(
+            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+        )
 
 
 def test_failed_workflow_execution(
     workflow_executor,
-    sample_workflow,
+    sample_workflow_1,
     mock_request_store,
     mock_resource_manager,
     mock_build_index_fn,
 ):
     """Test workflow execution with failure"""
-    error_message = "Build failed"
-    mock_build_index_fn.return_value = (False, None, error_message)
+    with patch("time.sleep"):
+        error_message = "Build failed"
+        mock_build_index_fn.return_value = (False, None, error_message)
 
-    workflow_executor.submit_workflow(sample_workflow)
-    workflow_executor._executor.shutdown(wait=True)
+        mock_resource_manager.allocate.return_value = True
 
-    mock_request_store.update.assert_called_with(
-        sample_workflow.job_id,
-        {"status": JobStatus.FAILED, "file_name": None, "error_message": error_message},
-    )
+        workflow_executor.submit_workflow(sample_workflow_1)
+        workflow_executor._executor.shutdown(wait=True)
 
+        mock_build_index_fn.assert_called_once_with(sample_workflow_1)
 
-def test_deleted_job_before_execution(
-    workflow_executor,
-    sample_workflow,
-    mock_request_store,
-    mock_resource_manager,
-    mock_build_index_fn,
-):
-    """Test handling of job that was deleted before execution"""
-    mock_request_store.get.return_value = False
+        mock_request_store.update.assert_called_with(
+            sample_workflow_1.job_id,
+            {
+                "status": JobStatus.FAILED,
+                "file_name": None,
+                "error_message": error_message,
+            },
+        )
 
-    workflow_executor.submit_workflow(sample_workflow)
-    workflow_executor._executor.shutdown(wait=True)
-
-    mock_build_index_fn.assert_not_called()
-    mock_request_store.update.assert_not_called()
+        mock_resource_manager.release.assert_called_with(
+            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+        )
 
 
 def test_deleted_job_during_execution(
     workflow_executor,
-    sample_workflow,
+    sample_workflow_1,
     mock_request_store,
     mock_resource_manager,
     mock_build_index_fn,
 ):
     """Test handling of job that was deleted during execution"""
-    # First get returns True, second returns False
-    mock_request_store.get.side_effect = [True, False]
 
-    workflow_executor.submit_workflow(sample_workflow)
-    workflow_executor._executor.shutdown(wait=True)
+    with patch("time.sleep"):
+        mock_resource_manager.allocate.return_value = True
+        mock_request_store.get.return_value = False
 
-    mock_build_index_fn.assert_called_once()
-    mock_request_store.update.assert_not_called()
+        workflow_executor.submit_workflow(sample_workflow_1)
+        workflow_executor._executor.shutdown(wait=True)
+
+        mock_build_index_fn.assert_called_once()
+        mock_request_store.update.assert_not_called()
+
+        mock_build_index_fn.assert_called_once()
+        mock_resource_manager.release.assert_called_with(
+            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+        )
 
 
 def test_exception_during_execution(
     workflow_executor,
-    sample_workflow,
+    sample_workflow_1,
     mock_request_store,
     mock_resource_manager,
     mock_build_index_fn,
 ):
     """Test handling of exceptions during execution"""
-    error_message = "Unexpected error"
-    mock_build_index_fn.side_effect = Exception(error_message)
+    with patch("time.sleep"):
+        error_message = "Unexpected error"
+        mock_build_index_fn.side_effect = Exception(error_message)
 
-    workflow_executor.submit_workflow(sample_workflow)
-    workflow_executor._executor.shutdown(wait=True)
+        mock_resource_manager.allocate.return_value = True
 
-    # mock_request_store.update.assert_called_with(
-    #     sample_workflow.job_id,
-    #     {"status": JobStatus.FAILED, "error_message": error_message}
-    # )
-    mock_request_store.update.assert_called_once()
+        workflow_executor.submit_workflow(sample_workflow_1)
+        workflow_executor._executor.shutdown(wait=True)
 
-    # Verify resources are released even after exception
-    mock_resource_manager.release.assert_called_with(
-        sample_workflow.gpu_memory_required, sample_workflow.cpu_memory_required
-    )
+        mock_request_store.update.assert_called_with(
+            sample_workflow_1.job_id,
+            {"status": JobStatus.FAILED, "error_message": error_message},
+        )
+        mock_build_index_fn.assert_called_once()
+
+        mock_resource_manager.release.assert_called_with(
+            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+        )
+
+
+def test_not_enough_memory_initially_successful_execution(
+    workflow_executor,
+    sample_workflow_1,
+    mock_request_store,
+    mock_resource_manager,
+    mock_build_index_fn,
+):
+    """
+    Test successful execution when there is not enough initial memory for the workflow
+    """
+
+    with patch("time.sleep") as patched_sleep:
+        mock_resource_manager.allocate.side_effect = (False, True)
+
+        mock_build_index_fn.return_value = (True, "/path/to/index", None)
+
+        workflow_executor.submit_workflow(sample_workflow_1)
+        workflow_executor._executor.shutdown(wait=True)
+
+        mock_build_index_fn.assert_called_once_with(sample_workflow_1)
+        assert patched_sleep.call_count == 2
+
+        mock_request_store.update.assert_called_with(
+            sample_workflow_1.job_id,
+            {
+                "status": JobStatus.COMPLETED,
+                "file_name": "/path/to/index",
+                "error_message": None,
+            },
+        )
+
+        mock_resource_manager.release.assert_called_with(
+            sample_workflow_1.gpu_memory_required, sample_workflow_1.cpu_memory_required
+        )
+
+
+def test_not_enough_memory_initially_deleted_job(
+    workflow_executor,
+    sample_workflow_1,
+    mock_request_store,
+    mock_resource_manager,
+    mock_build_index_fn,
+):
+    """Test handling of job that was deleted during the memory allocation check"""
+
+    with patch("time.sleep") as patched_sleep:
+        mock_resource_manager.allocate.return_value = False
+        mock_request_store.get.return_value = False
+
+        workflow_executor.submit_workflow(sample_workflow_1)
+        workflow_executor._executor.shutdown(wait=True)
+
+        assert patched_sleep.call_count == 1
+        mock_build_index_fn.assert_not_called()
+        mock_resource_manager.release.assert_not_called()
 
 
 def test_shutdown(workflow_executor):

--- a/test_remote_vector_index_builder/test_app/test_utils/test_memory.py
+++ b/test_remote_vector_index_builder/test_app/test_utils/test_memory.py
@@ -56,9 +56,7 @@ def test_basic_calculation():
     # Calculate expected values
     entry_size = 4  # FLOAT32 size
     vector_memory = 128 * 1000 * entry_size
-    expected_gpu_memory = (
-        (128 * entry_size + 16 * 8) * 1.1 * 1000
-    ) * 1.5 + vector_memory
+    expected_gpu_memory = ((128 * entry_size + 16 * 8) * 1.1 * 1000) * 0.5
     expected_cpu_memory = (128 * entry_size + 16 * 8) * 1.1 * 1000 + vector_memory
 
     assert gpu_memory == expected_gpu_memory


### PR DESCRIPTION
### Description
Allocates memory for the job in the workflow executor, instead of when the request is added to the request store. This ensures requests that get queued by the workflow executor don't take up memory when they are in a queued state. 

I also updated the E2E test to run the requests in parallel, and I updated the `config.py` file to allow the container settings  (such as GPU and CPU memory limits) to be configured via environment variable. This will allow us to simulate different test scenarios more easily.

### Issues Resolved
Resolves https://github.com/opensearch-project/remote-vector-index-builder/issues/63

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).