### PR TITLE
Added paths to trigger core and api image builds when base image changes

### DIFF
--- a/.github/workflows/publish_faiss_base_image.yml
+++ b/.github/workflows/publish_faiss_base_image.yml
@@ -61,3 +61,11 @@ jobs:
           docker logout
           docker system prune -a -f
           rm -rf ${{ github.workspace }}/*
+  
+  # Trigger build of core image since base image is changed
+  build-and-publish-core-image:
+    needs: build-and-publish-faiss-base-image
+    uses: ./.github/workflows/publish_remote_core_image.yml
+    secrets:
+      REMOTE_VECTOR_DOCKER_ROLE: ${{ secrets.REMOTE_VECTOR_DOCKER_ROLE }}
+      REMOTE_VECTOR_DOCKER_USERNAME: ${{ secrets.REMOTE_VECTOR_DOCKER_USERNAME }}

--- a/.github/workflows/publish_remote_api_image.yml
+++ b/.github/workflows/publish_remote_api_image.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'remote_vector_index_builder/app/**'
       - '.github/workflows/publish_remote_api_image.yml'
+
   workflow_call: # enables workflow to be reused
     secrets:
       REMOTE_VECTOR_DOCKER_USERNAME:

--- a/.github/workflows/publish_remote_core_image.yml
+++ b/.github/workflows/publish_remote_core_image.yml
@@ -54,6 +54,8 @@ jobs:
         if: always()
         run: |
           docker logout
+  
+  # Trigger the build of core image since api image is changed
   build-and-publish-api-image:
     needs: build-and-publish-core-image
     uses: ./.github/workflows/publish_remote_api_image.yml


### PR DESCRIPTION
### Description
Added paths to trigger core and api image builds when base image changes.

Reason for adding this is, whenever there is a change in base image, the core and api images which are published should also be updated since base is changed. If we don't do this, then published core and api images will be stale.

Similar thing is done for api image too, where api image is rebuild if changes in core or base image is there.

Thanks @rchitale7 for suggesting this.


### Issues Resolved
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).