### PR TITLE
Changed ivf_pq_build_params to ivf_pq_params

### DIFF
--- a/.github/workflows/publish_remote_core_image.yml
+++ b/.github/workflows/publish_remote_core_image.yml
@@ -8,6 +8,13 @@ on:
       - 'remote_vector_index_builder/core/**'
       - '.github/workflows/publish_remote_core_image.yml'
 
+  workflow_call: # enables workflow to be reused
+    secrets:
+      REMOTE_VECTOR_DOCKER_USERNAME:
+        required: true
+      REMOTE_VECTOR_DOCKER_ROLE:
+        required: true
+
 permissions:
   id-token: write
   contents: read

--- a/base_image/build_scripts/build-faiss.sh
+++ b/base_image/build_scripts/build-faiss.sh
@@ -36,5 +36,5 @@ echo "Running make command"
 # in which case it is recommended to set the -j option to a fixed value (such as -j6).
 make -C build -j6 faiss swigfaiss
 
-# Step 3: Generate and install python packages
+# Step 3: Generate and install python packages. 
 (cd build/faiss/python && python setup.py install)

--- a/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_gpu_index_cagra_builder.py
+++ b/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_gpu_index_cagra_builder.py
@@ -119,7 +119,7 @@ class FaissGPUIndexCagraBuilder(FaissGPUIndexBuilder):
         gpu_index_cagra_config.build_algo = self._configure_build_algo()
 
         if self.graph_build_algo == CagraGraphBuildAlgo.IVF_PQ:
-            gpu_index_cagra_config.ivf_pq_build_params = (
+            gpu_index_cagra_config.ivf_pq_params = (
                 self.ivf_pq_build_config.to_faiss_config()
             )
             gpu_index_cagra_config.ivf_pq_search_params = (
@@ -147,8 +147,8 @@ class FaissGPUIndexCagraBuilder(FaissGPUIndexBuilder):
         # Create a copy of params to avoid modifying the original
         params_copy = params.copy()
         # Extract and configure IVF-PQ build parameters
-        ivf_pq_build_params = params_copy.pop("ivf_pq_build_params", {})
-        ivf_pq_build_config = IVFPQBuildCagraConfig.from_dict(ivf_pq_build_params)
+        ivf_pq_params = params_copy.pop("ivf_pq_params", {})
+        ivf_pq_build_config = IVFPQBuildCagraConfig.from_dict(ivf_pq_params)
 
         # Extract and configure IVF-PQ search parameters
         ivf_pq_search_params = params_copy.pop("ivf_pq_search_params", {})
@@ -201,9 +201,11 @@ class FaissGPUIndexCagraBuilder(FaissGPUIndexBuilder):
             # Configure the distance metric
             metric = configure_metric(space_type)
 
+            res = faiss.StandardGpuResources()
+            res.noTempMemory()
             # Create GPU CAGRA index with specified configuration
             faiss_gpu_index = faiss.GpuIndexCagra(
-                faiss.StandardGpuResources(),
+                res,
                 dataset_dimension,
                 metric,
                 faiss_gpu_index_config,

--- a/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
+++ b/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
@@ -63,7 +63,7 @@ class FaissIndexBuildService(IndexBuildService):
             # Step 1a: Create a structured GPUIndexConfig having defaults,
             # from a partial dictionary set from index build params
             gpu_index_config_params = {
-                "ivf_pq_build_params": {
+                "ivf_pq_params": {
                     "n_lists": calculate_ivf_pq_n_lists(
                         index_build_parameters.doc_count
                     ),

--- a/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_gpu_index_caga_builder.py
+++ b/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_gpu_index_caga_builder.py
@@ -38,7 +38,7 @@ class TestFaissGPUIndexCagraBuilder:
             "store_dataset": True,
             "refine_rate": 3.0,
             "graph_build_algo": CagraGraphBuildAlgo.IVF_PQ,
-            "ivf_pq_build_params": {"n_lists": 2048},
+            "ivf_pq_params": {"n_lists": 2048},
             "ivf_pq_search_params": {"n_probes": 16},
         }
         return params
@@ -105,7 +105,7 @@ class TestFaissGPUIndexCagraBuilder:
 
         # Test IVF-PQ configurations if present
         if custom_builder.graph_build_algo == CagraGraphBuildAlgo.IVF_PQ:
-            assert config.ivf_pq_build_params is not None
+            assert config.ivf_pq_params is not None
             assert config.ivf_pq_search_params is not None
 
     def test_from_dict_custom(self, custom_params):
@@ -124,7 +124,7 @@ class TestFaissGPUIndexCagraBuilder:
 
         assert (
             builder.ivf_pq_build_config.n_lists
-            == custom_params["ivf_pq_build_params"]["n_lists"]
+            == custom_params["ivf_pq_params"]["n_lists"]
         )
         assert (
             builder.ivf_pq_search_config.n_probes


### PR DESCRIPTION
### Description
During benchmarking/validation, I noticed that the code was using `ivf_pq_build_params` instead of `ivf_pq_params` in setting the CAGRA ivf pq hyper parameters. What happens is that when we use `ivf_pq_build_params`, `pq_dim` gets automatically set to vector_dimensions/4, no matter what value you try to assign it. However, `ivf_pq_params` lets us modify `pq_dim` to whatever we want. 

I also added `res.noTempMemory()` to reduce the GPU memory allocations. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).