### PR TITLE
Set random rotation to true by default

### DIFF
--- a/remote_vector_index_builder/core/common/models/index_builder/faiss/ivf_pq_build_cagra_config.py
+++ b/remote_vector_index_builder/core/common/models/index_builder/faiss/ivf_pq_build_cagra_config.py
@@ -53,7 +53,7 @@ class IVFPQBuildCagraConfig:
     # to use as little GPU memory for the database as possible.
     conservative_memory_allocation: bool = True
 
-    force_random_rotation: bool = False
+    force_random_rotation: bool = True
 
     @staticmethod
     def _validate_params(params: Dict[str, Any]) -> None:

--- a/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_ivf_pq_build_cagra_config.py
+++ b/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_ivf_pq_build_cagra_config.py
@@ -37,7 +37,7 @@ class TestIVFPQBuildCagraConfig:
         assert default_config.pq_bits == 8
         assert default_config.pq_dim == 0
         assert default_config.conservative_memory_allocation is True
-        assert default_config.force_random_rotation is False
+        assert default_config.force_random_rotation is True
 
     def test_custom_initialization(self, custom_params):
         config = IVFPQBuildCagraConfig(**custom_params)
@@ -110,4 +110,4 @@ class TestIVFPQBuildCagraConfig:
         assert config.pq_bits == 8  # default value
         assert config.pq_dim == 0  # default value
         assert config.conservative_memory_allocation is True  # default value
-        assert config.force_random_rotation is False
+        assert config.force_random_rotation is True


### PR DESCRIPTION
### Description
`force_random_rotation` needs to be true by default. See https://github.com/opensearch-project/remote-vector-index-builder/issues/36. I was previously setting it to true in the benchmarking script I've been using, but it should be set to true in the code. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).