### PR TITLE
Publish Faiss Base Snapshot Image

### DIFF
--- a/.github/workflows/publish_faiss_base_image.yml
+++ b/.github/workflows/publish_faiss_base_image.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Remote-Vector-Index-Builder Faiss Base Image to Docker
+name: Build and Publish Remote-Vector-Index-Builder Faiss Base Snapshot Image to Docker
 
 on:
   push:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build-and-publish-faiss-base-image:
-    name: Build and Publish Remote-Vector-Index-Builder Faiss Base Image
+    name: Build and Publish Remote-Vector-Index-Builder Faiss Base Snapshot Image
     if: github.repository == 'opensearch-project/remote-vector-index-builder'
     runs-on:
       group: selfhosted-gpu-runners
@@ -28,8 +28,7 @@ jobs:
 
       - name: Build Docker Image
         run : |
-            docker build  -f ./base_image/build_scripts/Dockerfile . -t opensearchstaging/remote-vector-index-builder:faiss-base-1.0.0
-            docker tag opensearchstaging/remote-vector-index-builder:faiss-base-1.0.0 opensearchstaging/remote-vector-index-builder:faiss-base-latest
+            docker build  -f ./base_image/build_scripts/Dockerfile . -t opensearchstaging/remote-vector-index-builder:faiss-base-snapshot
       
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -52,8 +51,7 @@ jobs:
 
       - name: Push Docker Image
         run : |
-          docker push opensearchstaging/remote-vector-index-builder:faiss-base-1.0.0
-          docker push opensearchstaging/remote-vector-index-builder:faiss-base-latest
+          docker push opensearchstaging/remote-vector-index-builder:faiss-base-snapshot
 
       - name: Runner Cleanups
         if: always()


### PR DESCRIPTION
### Description
Update Faiss Base Image to publish faiss-base-snapshot instead of faiss-base-latest
Required to Merge before https://github.com/opensearch-project/remote-vector-index-builder/pull/78 for E2E CI to Pass

### Issues Resolved
Partly completes https://github.com/opensearch-project/remote-vector-index-builder/issues/77

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).