### PR TITLE
Change kmeans_trainset_fraction and pq_dim defaults

### DIFF
--- a/remote_vector_index_builder/core/common/models/index_builder/faiss/ivf_pq_build_cagra_config.py
+++ b/remote_vector_index_builder/core/common/models/index_builder/faiss/ivf_pq_build_cagra_config.py
@@ -22,7 +22,7 @@ class IVFPQBuildCagraConfig:
     # The number of iterations searching for kmeans centers (index building).
     kmeans_n_iters: int = 20
     # The fraction of data to use during iterative kmeans building.
-    kmeans_trainset_fraction: float = 0.5
+    kmeans_trainset_fraction: float = 0.1
 
     # The bit length of the vector element after compression by PQ.
     # Possible values: [4, 5, 6, 7, 8].

--- a/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
+++ b/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
@@ -32,6 +32,7 @@ class FaissIndexBuildService(IndexBuildService):
 
     def __init__(self):
         self.omp_num_threads = get_omp_num_threads()
+        self.PQ_DIM_COMPRESSION_FACTOR = 4
 
     def build_index(
         self,
@@ -67,7 +68,10 @@ class FaissIndexBuildService(IndexBuildService):
                     "n_lists": calculate_ivf_pq_n_lists(
                         index_build_parameters.doc_count
                     ),
-                    "pq_dim": index_build_parameters.dimension,
+                    "pq_dim": int(
+                        index_build_parameters.dimension
+                        / self.PQ_DIM_COMPRESSION_FACTOR
+                    ),
                 }
             }
             faiss_gpu_index_cagra_builder = FaissGPUIndexCagraBuilder.from_dict(

--- a/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_ivf_pq_build_cagra_config.py
+++ b/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_ivf_pq_build_cagra_config.py
@@ -33,7 +33,7 @@ class TestIVFPQBuildCagraConfig:
     def test_default_initialization(self, default_config):
         assert default_config.n_lists == 1024
         assert default_config.kmeans_n_iters == 20
-        assert default_config.kmeans_trainset_fraction == 0.5
+        assert default_config.kmeans_trainset_fraction == 0.1
         assert default_config.pq_bits == 8
         assert default_config.pq_dim == 0
         assert default_config.conservative_memory_allocation is True
@@ -106,7 +106,7 @@ class TestIVFPQBuildCagraConfig:
         config = IVFPQBuildCagraConfig.from_dict(partial_params)
         assert config.n_lists == 2048
         assert config.kmeans_n_iters == 30
-        assert config.kmeans_trainset_fraction == 0.5  # default value
+        assert config.kmeans_trainset_fraction == 0.1  # default value
         assert config.pq_bits == 8  # default value
         assert config.pq_dim == 0  # default value
         assert config.conservative_memory_allocation is True  # default value


### PR DESCRIPTION
### Description
Setting the `kmeans_trainset_fraction` and `pq_dim` hyper parameters to 0.1 and dim/4. `refine_rate` is already set to 2. This matches the best hyper param defaults found during these experiments: https://github.com/opensearch-project/remote-vector-index-builder/issues/36

### Issues Resolved
Closes https://github.com/opensearch-project/remote-vector-index-builder/issues/36

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).