### PR TITLE
Change cpu count factor for uploads

### DIFF
--- a/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
+++ b/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
@@ -118,7 +118,7 @@ class S3ObjectStore(ObjectStore):
 
         self.DEFAULT_UPLOAD_TRANSFER_CONFIG = {
             "multipart_chunksize": 50 * 1024 * 1024,  # 50MB
-            "max_concurrency": get_cpus(factor=0.25),
+            "max_concurrency": get_cpus(factor=0.5),
             "multipart_threshold": 50 * 1024 * 1024,  # 50MB
         }
 


### PR DESCRIPTION
### Description
Changing the number of vCPUs used for index uploads from `cpu_count * 0.25` to `cpu_count*0.5`. During download/upload benchmarking https://github.com/opensearch-project/remote-vector-index-builder/issues/23, I got the best results with `cpu_count*0.25`. However, these benchmarking results were generated for a machine with 16 vCPUs (4xlarge). When we use a machine with less vCPUs - such as 8, in the case of a 2xlarge machine - we see worse performance with `cpu_count*0.25` compared with `cpu_count*0.5`. My initial testing showed ~2x performance gain when using `cpu_count*0.5` instead of `cpu_count*0.25` for 2xl instances. Since `cpu_count*0.5` still performs well for 4xlarge, i'm setting the default to `cpu_count*0.5` to handle both 2xl and 4xl instances. 

### Issues Resolved
Resolves https://github.com/opensearch-project/remote-vector-index-builder/issues/66

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).