### PR TITLE
Change default refine rate to 1.0

### DIFF
--- a/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_gpu_index_cagra_builder.py
+++ b/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_gpu_index_cagra_builder.py
@@ -40,7 +40,7 @@ class FaissGPUIndexCagraBuilder(FaissGPUIndexBuilder):
 
     store_dataset: bool = False
 
-    refine_rate: float = 2.0
+    refine_rate: float = 1.0
 
     ivf_pq_build_config: IVFPQBuildCagraConfig = field(
         default_factory=IVFPQBuildCagraConfig

--- a/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_gpu_index_caga_builder.py
+++ b/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_gpu_index_caga_builder.py
@@ -54,7 +54,7 @@ class TestFaissGPUIndexCagraBuilder:
         assert default_builder.graph_degree == 32
         assert default_builder.graph_build_algo == CagraGraphBuildAlgo.IVF_PQ
         assert default_builder.store_dataset is False
-        assert default_builder.refine_rate == 2.0
+        assert default_builder.refine_rate == 1.0
         assert isinstance(default_builder.ivf_pq_build_config, IVFPQBuildCagraConfig)
         assert isinstance(default_builder.ivf_pq_search_config, IVFPQSearchCagraConfig)
 


### PR DESCRIPTION
### Description
During end to end benchmarking with an OpenSearch cluster on the 10M cohere dataset, we noticed that using refine rate = 1.0 instead of refine rate = 2.0 improves performance by +1.5x. Based on the hyperparameter tuning results here: https://github.com/opensearch-project/remote-vector-index-builder/issues/36, it's possible this change will slightly impact recall. However, the effect on the 10M cohere dataset is small (< 1%), and I think the benefit in reduced indexing time is worth it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).