### PR TITLE
Support Byte GPU Indexing

### DIFF
--- a/remote_vector_index_builder/app/Dockerfile
+++ b/remote_vector_index_builder/app/Dockerfile
@@ -12,7 +12,7 @@ USER root
 
 WORKDIR /app
 
-COPY ./remote_vector_index_builder/app/requirements.txt /app/remote_vector_index_builder/app/requirements.txt
+COPY ./remote_vector_index_builder/app /app/remote_vector_index_builder/app
 
 RUN pip install --no-cache-dir --upgrade -r /app/remote_vector_index_builder/app/requirements.txt
 

--- a/remote_vector_index_builder/core/common/models/index_build_parameters.py
+++ b/remote_vector_index_builder/core/common/models/index_build_parameters.py
@@ -22,6 +22,7 @@ class DataType(str, Enum):
     """
 
     FLOAT = "float"
+    BYTE = "byte"
 
     def get_size(self):
         """Get the size of the data type in bytes.
@@ -31,6 +32,8 @@ class DataType(str, Enum):
         """
         if self == DataType.FLOAT:
             return 4
+        elif self == DataType.BYTE:
+            return 1
         else:
             raise ValueError(f"Unsupported data type: {self}")
 

--- a/remote_vector_index_builder/core/common/models/vectors_dataset.py
+++ b/remote_vector_index_builder/core/common/models/vectors_dataset.py
@@ -28,6 +28,7 @@ class VectorsDataset:
 
     vectors: np.ndarray
     doc_ids: np.ndarray
+    dtype: DataType
 
     def free_vectors_space(self):
         """Free up memory by deleting the vectors and document IDs arrays."""
@@ -57,6 +58,8 @@ class VectorsDataset:
         """
         if dtype == DataType.FLOAT:
             return "<f4"
+        if dtype == DataType.BYTE:
+            return "<i1"
         else:
             raise UnsupportedVectorsDataTypeError(f"Unsupported data type: {dtype}")
 
@@ -118,4 +121,4 @@ class VectorsDataset:
 
         except (ValueError, TypeError, MemoryError, RuntimeError) as e:
             raise VectorsDatasetError(f"Error parsing vectors: {e}") from e
-        return VectorsDataset(np_vectors, np_doc_ids)
+        return VectorsDataset(np_vectors, np_doc_ids, vector_dtype)

--- a/test_remote_vector_index_builder/test_core/conftest.py
+++ b/test_remote_vector_index_builder/test_core/conftest.py
@@ -12,6 +12,7 @@ from types import ModuleType
 from unittest.mock import Mock
 
 from core.common.models import VectorsDataset
+from core.common.models.index_build_parameters import DataType
 
 
 class DeletionTracker:
@@ -91,7 +92,7 @@ class MockIndexIDMap:
     def is_deleted(self):
         return _deletion_tracker.is_deleted(self.id)
 
-    def add_with_ids(self, vectors, ids):
+    def add_with_ids(self, vectors, ids, numeric_type):
         pass
 
 
@@ -157,6 +158,8 @@ class FaissMock(ModuleType):
         self.IVFPQBuildCagraConfig = MockIVFPQBuildCagraConfig
         self.IVFPQSearchCagraConfig = MockIVFPQSearchCagraConfig
         self.GpuIndexCagraConfig = MockGpuIndexCagraConfig
+        self.Float32 = Mock()
+        self.Int8 = Mock()
 
         # Enums
         self.graph_build_algo_IVF_PQ = 1
@@ -225,4 +228,6 @@ def sample_doc_ids():
 @pytest.fixture
 def vectors_dataset(sample_vectors, sample_doc_ids):
     """Create a VectorsDataset instance for testing"""
-    return VectorsDataset(vectors=sample_vectors, doc_ids=sample_doc_ids)
+    return VectorsDataset(
+        vectors=sample_vectors, doc_ids=sample_doc_ids, dtype=DataType.FLOAT
+    )

--- a/test_remote_vector_index_builder/test_core/test_tasks.py
+++ b/test_remote_vector_index_builder/test_core/test_tasks.py
@@ -20,6 +20,7 @@ from core.tasks import (
 from core.common.exceptions import BlobError
 from core.common.models.vectors_dataset import VectorsDataset
 from core.object_store.object_store import ObjectStore
+from core.common.models.index_build_parameters import DataType
 
 
 @pytest.fixture
@@ -41,7 +42,12 @@ def mock_vectors_dataset_parse():
 
 @pytest.fixture
 def mock_vectors_dataset():
-    return Mock(spec=VectorsDataset, vectors=np.array([]), doc_ids=np.array([]))
+    return Mock(
+        spec=VectorsDataset,
+        vectors=np.array([]),
+        doc_ids=np.array([]),
+        dtype=DataType.FLOAT,
+    )
 
 
 def test_successful_creation(


### PR DESCRIPTION
### Description
This PR introduces changes to support GPU byte indexing which was not available. 
It is expected that raw byte vectors are stored in remote, and if it is triggered with datatype='byte', it will pass faiss.Int8 as a numeric type accordingly down to Cagra index builder.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).