### PR TITLE
FP16 streaming support

### DIFF
--- a/remote_vector_index_builder/core/common/models/index_build_parameters.py
+++ b/remote_vector_index_builder/core/common/models/index_build_parameters.py
@@ -22,6 +22,7 @@ class DataType(str, Enum):
     """
 
     FLOAT = "float"
+    FLOAT16 = "half_float"
     BYTE = "byte"
     BINARY = "binary"
 
@@ -33,6 +34,8 @@ class DataType(str, Enum):
         """
         if self == DataType.FLOAT:
             return 4
+        elif self == DataType.FLOAT16:
+            return 2
         elif self == DataType.BYTE:
             return 1
         elif self == DataType.BINARY:
@@ -51,6 +54,7 @@ class SpaceType(str, Enum):
 
     L2 = "l2"
     INNERPRODUCT = "innerproduct"
+    HAMMING = "hamming"
 
 
 class Algorithm(str, Enum):

--- a/remote_vector_index_builder/core/common/models/vectors_dataset.py
+++ b/remote_vector_index_builder/core/common/models/vectors_dataset.py
@@ -58,6 +58,8 @@ class VectorsDataset:
         """
         if dtype == DataType.FLOAT:
             return "<f4"
+        if dtype == DataType.FLOAT16:
+            return "<f2"
         if dtype == DataType.BYTE:
             return "<i1"
         if dtype == DataType.BINARY:
@@ -83,7 +85,7 @@ class VectorsDataset:
 
     @staticmethod
     def parse(
-        vectors: BytesIO,
+        vectors,
         doc_ids: BytesIO,
         dimension: int,
         doc_count: int,
@@ -95,7 +97,7 @@ class VectorsDataset:
         dimensions, and creates a new VectorsDataset instance.
 
         Args:
-            vectors (BytesIO): Binary stream containing vector data.
+            vectors (BytesIO like object): Binary stream containing vector data.
             doc_ids (BytesIO): Binary stream containing document IDs.
             dimension (int): The dimensionality of each vector.
             doc_count (int): Expected number of vectors/documents.

--- a/remote_vector_index_builder/core/fp32_to_fp16_converting_bytes_io.py
+++ b/remote_vector_index_builder/core/fp32_to_fp16_converting_bytes_io.py
@@ -1,0 +1,138 @@
+import os
+import numpy as np
+import threading
+
+"""
+This class converts raw FP32 byte streams into FP16 values and stores them in a pre-allocated FP16 NumPy array. It is
+designed to handle input arriving in multiple partitions from a continuous FP32 vector stream.
+Because a partition boundary may split an FP32 value across chunks, the class first identifies all complete FP32 values
+from the incoming bytes, converts them to FP16, and writes them into the FP16 array. Any remaining incomplete bytes are
+stored in a dictionary and reassembled once the rest of the bytes arrive in future partitions.
+
+For example, let's say we had 6 FP32 values as below:
+[[b0, b1, b2, b3], [b4, b5, b6, b7], [b8, b9, b10, b11], [b12, b13, b14, b15], [b16, b17, b18, b19],
+ [b20, b21, b22, b23]]
+where [b0, b1, b2, b3] represents four bytes for the first FP32 value.
+
+The FP32 data can be split across two partitions as shown below:
+Partition-1:
+[[b0, b1, b2, b3], [b4, b5, b6, b7], [b8, b9, b10, b11], [b12, b13]]
+
+Partition-2:
+[[b14, b15], [b16, b17, b18, b19], [b20, b21, b22, b23]]
+
+Assume partition-1 arrives before partition-2.
+This class first identifies complete FP32 values (each consisting of 4 bytes). From partition-1, the following groups
+are detected:
+
+    [[b0, b1, b2, b3], [b4, b5, b6, b7], [b8, b9, b10, b11]]
+
+These complete 4-byte chunks are immediately converted to FP16 values and stored in the FP16 NumPy array. Any remaining
+incomplete bytes — in this case [b12, b13] — are stored in a dictionary, keyed by the ordinal index of the FP32 vector,
+which is 3 here. (e.g. represents incomplete bytes for 3rd vector)
+
+When partition-2 arrives, the same logic is applied. It identifies complete FP32 values:
+
+    [[b16, b17, b18, b19], [b20, b21, b22, b23]]. These values will be put into FP16 numpy array.
+
+These are likewise converted and stored. Meanwhile, [b14, b15] are also recognized as belonging to the previously
+incomplete FP32 value at index 3. Now that all 4 bytes for that vector are available ([b12, b13, b14, b15]),
+they are reassembled, converted to FP16, and written to the FP16 array. The corresponding entry in the dictionary is
+then removed.
+"""
+
+
+class FP32ToFP16ConvertingBytesIO:
+    def __init__(self, num_floats):
+        self._fp16_np = np.zeros(num_floats, dtype=np.float16)
+        self._curr_offset = 0
+        self._incomplete_vector_value = dict()
+        self._lock = threading.Lock()
+
+    def seekable(self):
+        return True
+
+    def seek(self, offset, whence=0):
+        with self._lock:
+            if whence == os.SEEK_SET:
+                self._curr_offset = offset
+            elif whence == os.SEEK_CUR:
+                self._curr_offset += offset
+            elif whence == os.SEEK_END:
+                self._curr_offset = np.dtype(np.float32).itemsize * len(self._fp16_np)
+            else:
+                raise ValueError(f"Unexpected whence={whence}")
+
+    def getbuffer(self):
+        return memoryview(self._fp16_np)
+
+    def write(self, b):
+        with self._lock:
+            len_bytes = len(b)
+            # Determine the boundary of the first float value
+            # if byte_idx1 == 0, meaning the offset is located at the multiple of sizeof(float), the start offset of
+            # float value. Otherwise, it is pointing to incomplete bytes within one float value.
+            # For example, value_idx1=55, byte_idx1=2 then the offset is pointing to b2 in
+            # [...54 float values, [?, ?, b2, b3]]
+            value_idx1, byte_idx1 = FP32ToFP16ConvertingBytesIO._get_index(
+                self._curr_offset
+            )
+
+            # We skip incomplete float value for now when having non-zero byte_idx1
+            # Otherwise, we can use the given value_idx1
+            copy_start_index = value_idx1 if byte_idx1 == 0 else value_idx1 + 1
+
+            # Determine the boundary of the last float value
+            # if byte_idx2 == 0, the offset is located at the multiple of sizeof(float), the start offset of
+            # float value. Otherwise, it is pointing to incomplete bytes within one float value.
+            # For example, value_idx2=55, byte_idx2=2 then the offset is pointing to b2 in
+            # [...54 float values, [?, ?, b2, b3]]
+            actual_end_offset = self._curr_offset + len_bytes
+            value_idx2, byte_idx2 = FP32ToFP16ConvertingBytesIO._get_index(
+                actual_end_offset
+            )
+            copy_end_index = value_idx2
+
+            # Clip bytes to have complete float values
+            clip_start = 0 if byte_idx1 == 0 else 4 - byte_idx1
+            clip_end = len_bytes - byte_idx2
+            fp32_vector_values = np.frombuffer(b[clip_start:clip_end], dtype=np.float32)
+
+            # Convert FP32 values to FP16
+            self._fp16_np[copy_start_index:copy_end_index] = fp32_vector_values
+
+            # Try to assemble incomplete float value from leading and trailing
+            self._append_incomplete_bytes(value_idx1, b, 0, clip_start, byte_idx1)
+            self._append_incomplete_bytes(value_idx2, b, clip_end, len_bytes, 0)
+
+            self._curr_offset += len_bytes
+            return len_bytes
+
+    @staticmethod
+    def _get_index(offset):
+        return int(offset / 4), int(offset % 4)
+
+    def _append_incomplete_bytes(
+        self, value_idx, buffer, start_offset, end_offset, byte_idx
+    ):
+        if start_offset == end_offset:
+            return
+
+        bytes_count = self._incomplete_vector_value.get(value_idx)
+        if bytes_count is None:
+            bytes_count = {"count": 0, "bytes": [0] * 4}
+            self._incomplete_vector_value[value_idx] = bytes_count
+        four_bytes = bytes_count["bytes"]
+
+        offset = start_offset
+        while offset < end_offset:
+            four_bytes[byte_idx] = buffer[offset]
+            offset += 1
+            byte_idx += 1
+
+        bytes_count["count"] += end_offset - start_offset
+        if bytes_count["count"] == 4:
+            self._fp16_np[value_idx] = np.frombuffer(
+                bytes(four_bytes), dtype=np.float32
+            )[0]
+            del self._incomplete_vector_value[value_idx]

--- a/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
+++ b/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
@@ -11,7 +11,6 @@ import os
 import sys
 import threading
 from functools import cache
-from io import BytesIO
 from typing import Any, Dict
 
 import boto3
@@ -213,13 +212,13 @@ class S3ObjectStore(ObjectStore):
 
         return config_params
 
-    def read_blob(self, remote_store_path: str, bytes_buffer: BytesIO) -> None:
+    def read_blob(self, remote_store_path: str, bytes_buffer) -> None:
         """
         Downloads a blob from S3 to the provided bytes buffer, with retry logic.
 
         Args:
             remote_store_path (str): The S3 key (path) of the object to download
-            bytes_buffer (BytesIO): A bytes buffer to store the downloaded data
+            bytes_buffer: A bytes buffer to store the downloaded data
 
         Returns:
             None

--- a/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_gpu_index_caga_builder.py
+++ b/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_gpu_index_caga_builder.py
@@ -197,6 +197,9 @@ class TestFaissGPUIndexCagraBuilder:
     def test_build_gpu_byte_index_success(self, default_builder, byte_vectors_dataset):
         self._do_test_build_gpu_index_success(default_builder, byte_vectors_dataset)
 
+    def test_build_gpu_fp16_index_success(self, default_builder, fp16_vectors_dataset):
+        self._do_test_build_gpu_index_success(default_builder, fp16_vectors_dataset)
+
     def test_build_gpu_binary_index_success(
         self, default_builder, binary_vectors_dataset
     ):
@@ -225,6 +228,13 @@ class TestFaissGPUIndexCagraBuilder:
     ):
         self._do_test_build_gpu_index_config_error(
             default_builder, byte_vectors_dataset
+        )
+
+    def test_build_gpu_fp16_index_config_error(
+        self, default_builder, fp16_vectors_dataset
+    ):
+        self._do_test_build_gpu_index_config_error(
+            default_builder, fp16_vectors_dataset
         )
 
     def test_build_gpu_binary_index_config_error(
@@ -260,6 +270,13 @@ class TestFaissGPUIndexCagraBuilder:
     ):
         self._do_test_build_gpu_index_cleanup_on_error(
             default_builder, byte_vectors_dataset, deletion_tracker
+        )
+
+    def test_build_gpu_fp16_index_cleanup_on_error(
+        self, default_builder, fp16_vectors_dataset, deletion_tracker
+    ):
+        self._do_test_build_gpu_index_cleanup_on_error(
+            default_builder, fp16_vectors_dataset, deletion_tracker
         )
 
     def _do_test_build_gpu_index_cleanup_on_error(
@@ -334,6 +351,13 @@ class TestFaissGPUIndexCagraBuilder:
     ):
         self._do_test_build_gpu_index_resource_cleanup(
             default_builder, byte_vectors_dataset, deletion_tracker
+        )
+
+    def test_build_gpu_fp16_index_resource_cleanup(
+        self, default_builder, fp16_vectors_dataset, deletion_tracker
+    ):
+        self._do_test_build_gpu_index_resource_cleanup(
+            default_builder, fp16_vectors_dataset, deletion_tracker
         )
 
     def test_build_gpu_binary_index_resource_cleanup(

--- a/test_remote_vector_index_builder/test_core/conftest.py
+++ b/test_remote_vector_index_builder/test_core/conftest.py
@@ -226,6 +226,7 @@ class FaissMock(ModuleType):
         self.GpuIndexCagraConfig = MockGpuIndexCagraConfig
         self.IndexBinaryHNSW = MockIndexBinaryHNSW
         self.Float32 = Mock()
+        self.Float16 = Mock()
         self.Int8 = Mock()
 
         # Enums
@@ -340,6 +341,21 @@ def sample_byte_vectors():
 
 
 @pytest.fixture
+def sample_fp16_vectors():
+    """Generate sample fp16 vectors for testing"""
+    return np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+            [13.0, 14.0, 15.0],
+        ],
+        dtype=np.float16,
+    )
+
+
+@pytest.fixture
 def sample_doc_ids():
     """Generate sample document IDs for testing"""
     return np.array([1, 2, 3, 4, 5], dtype=np.int32)
@@ -354,16 +370,24 @@ def vectors_dataset(sample_vectors, sample_doc_ids):
 
 
 @pytest.fixture
-def byte_vectors_dataset(sample_vectors, sample_doc_ids):
+def byte_vectors_dataset(sample_byte_vectors, sample_doc_ids):
     """Create a VectorsDataset instance for testing"""
     return VectorsDataset(
-        vectors=sample_vectors, doc_ids=sample_doc_ids, dtype=DataType.BYTE
+        vectors=sample_byte_vectors, doc_ids=sample_doc_ids, dtype=DataType.BYTE
     )
 
 
 @pytest.fixture
-def binary_vectors_dataset(sample_vectors, sample_doc_ids):
+def binary_vectors_dataset(sample_binary_vectors, sample_doc_ids):
     """Create a VectorsDataset instance for testing"""
     return VectorsDataset(
-        vectors=sample_vectors, doc_ids=sample_doc_ids, dtype=DataType.BINARY
+        vectors=sample_binary_vectors, doc_ids=sample_doc_ids, dtype=DataType.BINARY
+    )
+
+
+@pytest.fixture
+def fp16_vectors_dataset(sample_fp16_vectors, sample_doc_ids):
+    """Create a VectorsDataset instance for testing"""
+    return VectorsDataset(
+        vectors=sample_fp16_vectors, doc_ids=sample_doc_ids, dtype=DataType.FLOAT16
     )

--- a/test_remote_vector_index_builder/test_core/index_builder/test_faiss_index_build_service.py
+++ b/test_remote_vector_index_builder/test_core/index_builder/test_faiss_index_build_service.py
@@ -36,6 +36,13 @@ class TestFaissIndexBuildService:
             service, byte_vectors_dataset, byte_index_build_parameters, tmp_path
         )
 
+    def test_build_fp16_index_success(
+        self, service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
+    ):
+        self._do_test_build_index_success(
+            service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
+        )
+
     def test_build_binary_index_success(
         self, service, binary_vectors_dataset, binary_index_build_parameters, tmp_path
     ):
@@ -65,6 +72,13 @@ class TestFaissIndexBuildService:
     ):
         self._do_test_build_index_gpu_creation_error(
             service, byte_vectors_dataset, byte_index_build_parameters, tmp_path
+        )
+
+    def test_build_fp16_index_gpu_creation_error(
+        self, service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
+    ):
+        self._do_test_build_index_gpu_creation_error(
+            service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
         )
 
     def test_build_binary_index_gpu_creation_error(
@@ -105,6 +119,13 @@ class TestFaissIndexBuildService:
             service, byte_vectors_dataset, byte_index_build_parameters, tmp_path
         )
 
+    def test_build_fp16_index_cpu_conversion_error(
+        self, service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
+    ):
+        self._do_test_build_index_cpu_conversion_error(
+            service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
+        )
+
     def test_build_binary_index_cpu_conversion_error(
         self, service, binary_vectors_dataset, binary_index_build_parameters, tmp_path
     ):
@@ -140,6 +161,13 @@ class TestFaissIndexBuildService:
     ):
         self._do_test_build_index_write_error(
             service, byte_vectors_dataset, byte_index_build_parameters, tmp_path
+        )
+
+    def test_build_fp16_index_write_error(
+        self, service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
+    ):
+        self._do_test_build_index_write_error(
+            service, fp16_vectors_dataset, byte_index_build_parameters, tmp_path
         )
 
     def test_build_binary_index_write_error(

--- a/test_remote_vector_index_builder/test_core/test_fp32_to_fp16_converting_bytes_io.py
+++ b/test_remote_vector_index_builder/test_core/test_fp32_to_fp16_converting_bytes_io.py
@@ -1,0 +1,187 @@
+import numpy as np
+
+from remote_vector_index_builder.core.fp32_to_fp16_converting_bytes_io import (
+    FP32ToFP16ConvertingBytesIO,
+)
+
+dimension = 64
+n_vectors = 100
+total_vectors = dimension * n_vectors
+
+
+def _test_fp32_to_fp16_conversion(fp32: np.ndarray, fp16: np.ndarray):
+    assert fp32.dtype == np.float32, "Input array 'fp32' must be of dtype float32"
+    assert fp16.dtype == np.float16, "Input array 'fp16' must be of dtype float16"
+    assert fp32.shape == fp16.shape, "Input arrays must have the same shape"
+
+    expected_fp16 = fp32.astype(np.float16)
+    np.testing.assert_array_equal(fp16, expected_fp16)
+
+
+def test1_perfect_match():
+    bytes_io = FP32ToFP16ConvertingBytesIO(total_vectors)
+    fp32_values = np.random.uniform(-100, 100, size=total_vectors).astype(np.float32)
+    bytes_to_write = fp32_values.tobytes()
+
+    # Write first 10 vectors
+    bytes_io.seek(0)
+    ret = bytes_io.write(bytes_to_write[0:40])
+    assert ret == 40
+
+    _test_fp32_to_fp16_conversion(fp32_values[0:10], bytes_io._fp16_np[0:10])
+
+    # write 10 vectors from third.
+    bytes_io = FP32ToFP16ConvertingBytesIO(total_vectors)
+    bytes_io.seek(0)
+    ret = bytes_io.write(bytes_to_write[4 * 3 : 4 * 3 + 40])
+    assert ret == 40
+
+    _test_fp32_to_fp16_conversion(fp32_values[3:13], bytes_io._fp16_np[0:10])
+
+
+def test2_incomplete_bytes_leading():
+    offsets = [1, 2, 3]
+    for o in offsets:
+        bytes_io = FP32ToFP16ConvertingBytesIO(total_vectors)
+        fp32_values = np.random.uniform(-100, 100, size=total_vectors).astype(
+            np.float32
+        )
+        bytes_to_write = fp32_values.tobytes()
+        org_bytes_to_write = bytes_to_write
+
+        # Write 'incomplete bytes of 4th vector' + '10 vectors' after
+        # e.g. 'incomplete bytes of 4th vector', fp16 <- fp32[5:15]
+        write_start_offset = 20 - o
+        bytes_io.seek(write_start_offset)
+        bytes_to_write = bytes_to_write[
+            write_start_offset : write_start_offset + o + 4 * 10
+        ]
+        ret = bytes_io.write(bytes_to_write)
+        assert ret == o + 4 * 10
+
+        # Check converted fp16 vectors
+        _test_fp32_to_fp16_conversion(fp32_values[5:15], bytes_io._fp16_np[5:15])
+
+        # Check if it has incomplete bytes correctly
+        vector_idx = 4
+        assert vector_idx in bytes_io._incomplete_vector_value
+        assert bytes_io._incomplete_vector_value[vector_idx]["count"] == o
+        j = 0  # Index of bytes_to_write
+        i = 4 - o
+        while i < 4:
+            assert (
+                bytes_io._incomplete_vector_value[vector_idx]["bytes"][i]
+                == bytes_to_write[j]
+            )
+            j += 1
+            i += 1
+
+        # Write remaining. e.g. 'incomplete bytes of 4th vector' + fp16 <- fp32[0:4]
+        bytes_to_write = org_bytes_to_write[0:write_start_offset]
+        bytes_io.seek(0)
+        ret = bytes_io.write(bytes_to_write)
+        assert ret == write_start_offset
+
+        # Expect it should complete 4th vector.
+        _test_fp32_to_fp16_conversion(fp32_values[0:5], bytes_io._fp16_np[0:5])
+
+        assert vector_idx not in bytes_io._incomplete_vector_value
+
+
+def test3_incomplete_bytes_trailing():
+    offsets = [1, 2, 3]
+    for o in offsets:
+        bytes_io = FP32ToFP16ConvertingBytesIO(total_vectors)
+        fp32_values = np.random.uniform(-100, 100, size=total_vectors).astype(
+            np.float32
+        )
+        bytes_to_write = fp32_values.tobytes()
+        org_bytes_to_write = bytes_to_write
+
+        # Write '10 vectors' + 'incomplete bytes of 5th vector' after 4 vectors.
+        # e.g. fp16 <- fp32[4:14], and one incomplete bytes
+        write_start_offset = 16
+        bytes_io.seek(write_start_offset)
+        bytes_to_write = bytes_to_write[
+            write_start_offset : write_start_offset + 4 * 10 + o
+        ]
+        ret = bytes_io.write(bytes_to_write)
+        assert ret == o + 4 * 10
+
+        # Check converted fp16 vectors
+        _test_fp32_to_fp16_conversion(fp32_values[4:14], bytes_io._fp16_np[4:14])
+
+        # Check if it has incomplete bytes correctly
+        vector_idx = 14
+        assert vector_idx in bytes_io._incomplete_vector_value
+        assert bytes_io._incomplete_vector_value[vector_idx]["count"] == o
+        j = 4 * 10  # Index of bytes_to_write
+        i = 0
+        while i < o:
+            assert (
+                bytes_io._incomplete_vector_value[vector_idx]["bytes"][i]
+                == bytes_to_write[j]
+            )
+            j += 1
+            i += 1
+
+        # Write 'incomplete bytes in 14th vector' + 10 vectors.
+        # e.g. 'incomplete bytes in 14th vector', fp16 <- fp32[15:25]
+        s = write_start_offset + 4 * 10 + o
+        bytes_to_write = org_bytes_to_write[s : s + 4 - o + 4 * 10]
+        ret = bytes_io.write(bytes_to_write)
+        assert ret == 4 * 10 + 4 - o
+        _test_fp32_to_fp16_conversion(fp32_values[14:25], bytes_io._fp16_np[14:25])
+
+        assert vector_idx not in bytes_io._incomplete_vector_value
+
+
+def test4_incomplete_bytes_leading_trailing():
+    offsets = [1, 2, 3]
+    for o in offsets:
+        for o2 in offsets:
+            bytes_io = FP32ToFP16ConvertingBytesIO(total_vectors)
+            fp32_values = np.random.uniform(-100, 100, size=total_vectors).astype(
+                np.float32
+            )
+            bytes_to_write = fp32_values.tobytes()
+
+            # Convert fp32[5:15] + incomplete bytes in 4th + incomplete bytes in 15th
+            write_start_offset = 20 - o
+            bytes_io.seek(write_start_offset)
+            bytes_to_write = bytes_to_write[
+                write_start_offset : write_start_offset + o + 4 * 10 + o2
+            ]
+            ret = bytes_io.write(bytes_to_write)
+            assert ret == o + 4 * 10 + o2
+
+            # Check converted fp16 vectors
+            _test_fp32_to_fp16_conversion(fp32_values[5:15], bytes_io._fp16_np[5:15])
+
+            # Check if it has incomplete bytes correctly
+            vector_idx = 4
+            assert vector_idx in bytes_io._incomplete_vector_value
+            assert bytes_io._incomplete_vector_value[vector_idx]["count"] == o
+            j = 0  # Index of bytes_to_write
+            i = 4 - o
+            while i < 4:
+                assert (
+                    bytes_io._incomplete_vector_value[vector_idx]["bytes"][i]
+                    == bytes_to_write[j]
+                )
+                j += 1
+                i += 1
+
+            # Check if it has incomplete bytes correctly
+            vector_idx = 15
+            assert vector_idx in bytes_io._incomplete_vector_value
+            assert bytes_io._incomplete_vector_value[vector_idx]["count"] == o2
+            j = 4 * 10 + o  # Index of bytes_to_write
+            i = 0
+            while i < o2:
+                assert (
+                    bytes_io._incomplete_vector_value[vector_idx]["bytes"][i]
+                    == bytes_to_write[j]
+                )
+                j += 1
+                i += 1


### PR DESCRIPTION
### Description
This PR introduces streaming FP16 conversion when downloading FP32 vectors that uploaded by data node.
The logic presented in this PR is to have FP32ToFP16ConvertingBytesIO to take raw bytes, then directly convert the given bytes to FP16 vectors without additional allocation.

With this, we can guarantee that the maximum memory space would be bound to O(SizeOf(FP16 vectors)) even when FP32 vectors uploaded in S3.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).