### PR TITLE
Updating the Faiss Build CI to checkout under a subdirectory

### DIFF
--- a/.github/workflows/publish_faiss_base_image.yml
+++ b/.github/workflows/publish_faiss_base_image.yml
@@ -25,9 +25,11 @@ jobs:
         uses: actions/checkout@v4
         with:
             submodules: 'recursive'
+            path: 'rvib'
 
       - name: Build Docker Image
         run : |
+            cd rvib
             docker build  -f ./base_image/build_scripts/Dockerfile . -t opensearchstaging/remote-vector-index-builder:faiss-base-snapshot
       
       - name: Configure AWS Credentials
@@ -56,8 +58,11 @@ jobs:
       - name: Runner Cleanups
         if: always()
         run: |
+          # Docker cleanup
           docker logout
           docker system prune -a -f
+          
+          # Workspace cleanup
           rm -rf ${{ github.workspace }}/*
   
   # Trigger build of core image since base image is changed

--- a/base_image/build_scripts/Dockerfile
+++ b/base_image/build_scripts/Dockerfile
@@ -25,6 +25,10 @@ RUN chown -R appuser:appuser /tmp
 USER appuser
 # Put conda in path so we can use conda activate
 ENV PATH=$CONDA_DIR/bin:$PATH
+
+# Accept Conda Terms of Service
+ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes
+
 #install some necessary dependencies
 RUN conda install -c conda-forge -y -q python=3.11 cmake=3.30.4 make=4.2 swig=4.0 "numpy<2" scipy=1.14 pytest=7.4 gflags=2.2
 RUN cmake --version


### PR DESCRIPTION
### Description
A git checkout with submodules caches the faiss commit under .git folder in workspace.
The .git folder is not cleared.

Updating the CI to checkout under a subdirectory 'rvib'

and deleting the directory after CI action is complete, via workspace cleanup
'rm -rf ${{ github.workspace }}/*'

Tested the image build by adding a pull_request trigger. Removed the trigger before raising this PR.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).