### PR TITLE
Bumping up Faiss to have reusing memory optimization.

### DIFF
--- a/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_index_hnsw_cagra_builder.py
+++ b/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_index_hnsw_cagra_builder.py
@@ -98,14 +98,13 @@ class FaissIndexHNSWCagraBuilder(FaissCPUIndexBuilder):
     ):
         try:
             # Convert GPU binary index to CPU binary index
-            cpu_index = faiss.index_binary_gpu_to_cpu(
-                faiss_gpu_build_index_output.gpu_index
-            )
-
-            # Configure CPU Index parameters
+            cpu_index = faiss.IndexBinaryHNSWCagra()
             cpu_index.hnsw.efConstruction = self.ef_construction
             cpu_index.hnsw.efSearch = self.ef_search
             cpu_index.base_level_only = self.base_level_only
+
+            # Convert GPU binary index to CPU binary index
+            faiss_gpu_build_index_output.gpu_index.copyTo(cpu_index)
 
             # Remove reference of GPU Index from the IndexBinaryIDMap
             faiss_gpu_build_index_output.index_id_map.index = None

--- a/test_remote_vector_index_builder/test_core/conftest.py
+++ b/test_remote_vector_index_builder/test_core/conftest.py
@@ -94,8 +94,8 @@ class MockGpuIndexBinaryCagra:
 
     def copyTo(self, cpu_index):
         """Mock implementation of copyTo method"""
-        if not isinstance(cpu_index, MockIndexBinaryHNSW):
-            raise TypeError("Target must be IndexBinaryHNSW")
+        if not isinstance(cpu_index, MockIndexBinaryHNSWCagra):
+            raise TypeError("Target must be MockIndexBinaryHNSWCagra")
         # Simulate copying data to CPU index
         return True
 
@@ -151,6 +151,22 @@ class MockIndexHNSWCagra(Mock):
         super().__init__(*args, **kwargs)
         self.hnsw = Mock()
         self.base_level_only = True
+
+    def __del__(self):
+        _deletion_tracker.mark_deleted(self.id)
+
+    @property
+    def is_deleted(self):
+        return _deletion_tracker.is_deleted(self.id)
+
+
+class MockIndexBinaryHNSWCagra(Mock):
+    """Mock for IndexBinaryHNSWCagra"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.hnsw = Mock()
+        self.base_level_only = False
 
     def __del__(self):
         _deletion_tracker.mark_deleted(self.id)
@@ -218,6 +234,7 @@ class FaissMock(ModuleType):
         self.StandardGpuResources = Mock()
         self.GpuIndexCagra = MockGpuIndexCagra
         self.GpuIndexBinaryCagra = MockGpuIndexBinaryCagra
+        self.IndexBinaryHNSWCagra = MockIndexBinaryHNSWCagra
         self.IndexIDMap = MockIndexIDMap
         self.IndexBinaryIDMap = MockIndexBinaryIDMap
         self.IndexHNSWCagra = MockIndexHNSWCagra


### PR DESCRIPTION
### Description
Bumping up Faiss version to have the reusing memory during index conversion optimization.
Without this, byte index conversion will use twice bigger memory.

https://github.com/facebookresearch/faiss/pull/4477

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).