### PR TITLE
Support calculating graph degree and intermediate graph degree from m for binary cagra

### DIFF
--- a/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
+++ b/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
@@ -85,7 +85,11 @@ class FaissIndexBuildService(IndexBuildService):
                 }
             else:
                 gpu_index_config_params = {
-                    "graph_build_algo": CagraGraphBuildAlgo.NN_DESCENT
+                    "graph_build_algo": CagraGraphBuildAlgo.NN_DESCENT,
+                    "graph_degree": index_build_parameters.index_parameters.algorithm_parameters.m
+                    * 2,
+                    "intermediate_graph_degree": index_build_parameters.index_parameters.algorithm_parameters.m
+                    * 4,
                 }
 
             faiss_gpu_index_cagra_builder = FaissGPUIndexCagraBuilder.from_dict(

--- a/test_remote_vector_index_builder/test_core/index_builder/test_faiss_index_build_service.py
+++ b/test_remote_vector_index_builder/test_core/index_builder/test_faiss_index_build_service.py
@@ -93,7 +93,13 @@ class TestFaissIndexBuildService:
                 * 4,
             }
         else:
-            return {"graph_build_algo": CagraGraphBuildAlgo.NN_DESCENT}
+            return {
+                "graph_build_algo": CagraGraphBuildAlgo.NN_DESCENT,
+                "graph_degree": index_build_parameters.index_parameters.algorithm_parameters.m
+                * 2,
+                "intermediate_graph_degree": index_build_parameters.index_parameters.algorithm_parameters.m
+                * 4,
+            }
 
     def test_build_index_gpu_creation_error(
         self, service, vectors_dataset, index_build_parameters, tmp_path


### PR DESCRIPTION
Fixes a bug with creating the `FaissGpuIndexCagra` object for `Binary` data type. We need to calculate graph degree and intermediate graph degree from m for binary, in addition to fp32, fp16, and byte. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).