### PR TITLE
Adding skip_stored_vectors parameter to skip graph storage

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,7 +16,7 @@ Request Parameters
     "tenant_id": "UniqueClusterID", // Unique identifier for the cluster making the request
     "dimension": 768,
     "doc_count": 1000000, // Must be greater than 4
-    "data_type": "float",
+    "data_type": // {float, half_float, byte, binary}
     "engine": "faiss",
     "index_parameters": {
         "space_type": // {l2, innerproduct}
@@ -26,7 +26,8 @@ Request Parameters
             "ef_search": 100,
             "m": 16
         }
-    }
+    }, 
+    "skip_stored_vectors": false
 }
 
 Request Response:
@@ -47,6 +48,7 @@ Request Response:
 * By including an `algorithm` field in index parameters, we leave the door open for IVF, future algorithms
 * The existing algorithm parameters will be type checked on the client and server side, but the size of the map is variable to allow for future parameter additions
 * Qualitative parameters like `repository_type`, `data_type`, `engine`, `algorithm`, and `space_type` currently only support the options listed. The other numerical and string settings follow k-NN/repository snapshot precedent on ranges and expected values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
+* `skip_stored_vectors` controls whether to send only the HNSW graph structure back, or the HNSW graph structure with flat vectors attached. It defaults to `false`. If `true`, the k-NN data node must handle stitching the graph back together with the flat vectors at indexing or search time. 
 
 #### Error codes
 

--- a/base_image/build_scripts/Dockerfile
+++ b/base_image/build_scripts/Dockerfile
@@ -18,6 +18,8 @@ RUN chown -R appuser:appuser /opt
 
 RUN mkdir /tmp/faiss
 COPY ./base_image/faiss /tmp/faiss
+COPY ./base_image/patches /tmp/patches
+RUN cd /tmp/faiss && patch -p1 < /tmp/patches/0001-Skip-copying-vectors-to-flat-storage-during-CAGRA-to.patch
 COPY ./base_image/build_scripts/build-faiss.sh /tmp/build-faiss.sh
 
 RUN chown -R appuser:appuser /tmp
@@ -37,7 +39,7 @@ RUN cmake --version
 ENV CUDA_ARCHS "80;86-real"
 
 # install base packages for X86_64
-RUN conda install -y -q -c conda-forge gxx_linux-64=14.2 sysroot_linux-64=2.17
+RUN conda install -y -q -c conda-forge gxx_linux-64=14.2 sysroot_linux-64=2.28
 
 # install all the dependencies we need for installing faiss
 # Ref: https://github.com/facebookresearch/faiss/blob/main/.github/actions/build_cmake/action.yml#L64

--- a/base_image/patches/0001-Skip-copying-vectors-to-flat-storage-during-CAGRA-to.patch
+++ b/base_image/patches/0001-Skip-copying-vectors-to-flat-storage-during-CAGRA-to.patch
@@ -1,0 +1,254 @@
+From 563504178a4f181ad550a39ce5e216547b617326 Mon Sep 17 00:00:00 2001
+From: Rohan Chitale <r.chitale7@gmail.com>
+Date: Mon, 16 Mar 2026 02:20:43 +0000
+Subject: [PATCH] Skip copying vectors to flat storage during CAGRA to HNSW
+ conversion when skip_storage=true
+
+---
+ faiss/gpu/GpuIndexBinaryCagra.cu | 27 +++++++++++++++++----------
+ faiss/gpu/GpuIndexBinaryCagra.h  |  7 +++++--
+ faiss/gpu/GpuIndexCagra.cu       | 15 +++++++++------
+ faiss/gpu/GpuIndexCagra.h        |  7 +++++--
+ faiss/impl/index_read.cpp        |  4 +++-
+ faiss/impl/index_write.cpp       | 21 +++++++++++++--------
+ faiss/index_io.h                 |  6 +++---
+ 7 files changed, 55 insertions(+), 32 deletions(-)
+
+diff --git a/faiss/gpu/GpuIndexBinaryCagra.cu b/faiss/gpu/GpuIndexBinaryCagra.cu
+index 3acb23714..b377b2f4b 100644
+--- a/faiss/gpu/GpuIndexBinaryCagra.cu
++++ b/faiss/gpu/GpuIndexBinaryCagra.cu
+@@ -308,7 +308,9 @@ void GpuIndexBinaryCagra::copyFrom(const faiss::IndexBinaryHNSWCagra* index) {
+     this->is_trained = true;
+ }
+ 
+-void GpuIndexBinaryCagra::copyTo(faiss::IndexBinaryHNSWCagra* index) const {
++void GpuIndexBinaryCagra::copyTo(
++        faiss::IndexBinaryHNSWCagra* index,
++        bool skip_storage) const {
+     FAISS_ASSERT(index_ && this->is_trained && index);
+ 
+     DeviceScope scope(cagraConfig_.device);
+@@ -338,19 +340,24 @@ void GpuIndexBinaryCagra::copyTo(faiss::IndexBinaryHNSWCagra* index) const {
+     auto n_train = this->ntotal;
+     auto stream = resources_->getDefaultStream(cagraConfig_.device);
+ 
+-    auto train_dataset = toHost<uint8_t, 2>(
+-            const_cast<uint8_t*>(index_->get_training_dataset()),
+-            stream,
+-            {idx_t(n_train), this->d / 8});
+-
+     // turn off as level 0 is copied from CAGRA graph
+     index->init_level0 = false;
+-    if (!index->base_level_only) {
+-        index->add(n_train, train_dataset.data());
+-    } else {
++    if (skip_storage) {
+         index->hnsw.prepare_level_tab(n_train, false);
+-        index->storage->add(n_train, train_dataset.data());
+         index->ntotal = n_train;
++    } else {
++        auto train_dataset = toHost<uint8_t, 2>(
++                const_cast<uint8_t*>(index_->get_training_dataset()),
++                stream,
++                {idx_t(n_train), this->d / 8});
++
++        if (!index->base_level_only) {
++            index->add(n_train, train_dataset.data());
++        } else {
++            index->hnsw.prepare_level_tab(n_train, false);
++            index->storage->add(n_train, train_dataset.data());
++            index->ntotal = n_train;
++        }
+     }
+ 
+     auto graph = get_knngraph();
+diff --git a/faiss/gpu/GpuIndexBinaryCagra.h b/faiss/gpu/GpuIndexBinaryCagra.h
+index 30da20785..1a9f05d50 100644
+--- a/faiss/gpu/GpuIndexBinaryCagra.h
++++ b/faiss/gpu/GpuIndexBinaryCagra.h
+@@ -67,8 +67,11 @@ struct GpuIndexBinaryCagra : public IndexBinary {
+     void copyFrom(const faiss::IndexBinaryHNSWCagra* index);
+ 
+     /// Copy ourselves to the given CPU index; will overwrite all data
+-    /// in the index instance
+-    void copyTo(faiss::IndexBinaryHNSWCagra* index) const;
++    /// in the index instance. If skip_storage is true, vectors are not
++    /// copied to the flat storage, reducing CPU memory usage.
++    void copyTo(
++            faiss::IndexBinaryHNSWCagra* index,
++            bool skip_storage = false) const;
+ 
+     void reset() override;
+ 
+diff --git a/faiss/gpu/GpuIndexCagra.cu b/faiss/gpu/GpuIndexCagra.cu
+index fe6760619..40cc55691 100644
+--- a/faiss/gpu/GpuIndexCagra.cu
++++ b/faiss/gpu/GpuIndexCagra.cu
+@@ -389,7 +389,9 @@ void GpuIndexCagra::copyFrom(const faiss::IndexHNSWCagra* index) {
+     copyFromEx(index, NumericType::Float32);
+ }
+ 
+-void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {
++void GpuIndexCagra::copyTo(
++        faiss::IndexHNSWCagra* index,
++        bool skip_storage) const {
+     FAISS_ASSERT(
+             !std::holds_alternative<std::monostate>(index_) &&
+             this->is_trained && index);
+@@ -451,7 +453,12 @@ void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {
+     auto n_train = this->ntotal;
+     bool allocation = false;
+ 
+-    if (numeric_type_ == NumericType::Float32) {
++    // turn off as level 0 is copied from CAGRA graph
++    index->init_level0 = false;
++    if (skip_storage) {
++        index->hnsw.prepare_level_tab(n_train, false);
++        index->ntotal = n_train;
++    } else if (numeric_type_ == NumericType::Float32) {
+         float* train_dataset;
+         const float* dataset =
+                 std::get<std::shared_ptr<CuvsCagra<float>>>(index_)
+@@ -469,8 +476,6 @@ void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {
+             train_dataset = const_cast<float*>(dataset);
+         }
+ 
+-        // turn off as level 0 is copied from CAGRA graph
+-        index->init_level0 = false;
+         if (!index->base_level_only) {
+             index->add(n_train, train_dataset);
+         } else {
+@@ -498,7 +503,6 @@ void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {
+             train_dataset = const_cast<half*>(dataset);
+         }
+ 
+-        index->init_level0 = false;
+         if (!index->base_level_only) {
+             FAISS_THROW_MSG(
+                     "Only base level copy is supported for FP16 types in GpuIndexCagra::copyTo");
+@@ -530,7 +534,6 @@ void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {
+             train_dataset = const_cast<int8_t*>(dataset);
+         }
+ 
+-        index->init_level0 = false;
+         if (!index->base_level_only) {
+             FAISS_THROW_MSG(
+                     "Only base level copy is supported for Int8 types in GpuIndexCagra::copyTo");
+diff --git a/faiss/gpu/GpuIndexCagra.h b/faiss/gpu/GpuIndexCagra.h
+index 72dcf074e..8e94e2542 100644
+--- a/faiss/gpu/GpuIndexCagra.h
++++ b/faiss/gpu/GpuIndexCagra.h
+@@ -276,8 +276,11 @@ struct GpuIndexCagra : public GpuIndex {
+             NumericType numeric_type);
+ 
+     /// Copy ourselves to the given CPU index; will overwrite all data
+-    /// in the index instance
+-    void copyTo(faiss::IndexHNSWCagra* index) const;
++    /// in the index instance. If skip_storage is true, vectors are not
++    /// copied to the flat storage, reducing CPU memory usage.
++    void copyTo(
++            faiss::IndexHNSWCagra* index,
++            bool skip_storage = false) const;
+ 
+     void reset() override;
+ 
+diff --git a/faiss/impl/index_read.cpp b/faiss/impl/index_read.cpp
+index 89f05c757..5d2a768f9 100644
+--- a/faiss/impl/index_read.cpp
++++ b/faiss/impl/index_read.cpp
+@@ -1374,7 +1374,9 @@ IndexBinary* read_index_binary(IOReader* f, int io_flags) {
+     IndexBinary* idx = nullptr;
+     uint32_t h;
+     READ1(h);
+-    if (h == fourcc("IBxF")) {
++    if (h == fourcc("null")) {
++        return nullptr;
++    } else if (h == fourcc("IBxF")) {
+         IndexBinaryFlat* idxf = new IndexBinaryFlat();
+         read_index_binary_header(idxf, f);
+         read_vector(idxf->xb, f);
+diff --git a/faiss/impl/index_write.cpp b/faiss/impl/index_write.cpp
+index def7dcd2b..b2df5bab6 100644
+--- a/faiss/impl/index_write.cpp
++++ b/faiss/impl/index_write.cpp
+@@ -765,7 +765,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
+         // no need to store additional info for IndexIDMap2
+         WRITE1(h);
+         write_index_header(idxmap, f);
+-        write_index(idxmap->index, f);
++        write_index(idxmap->index, f, io_flags);
+         WRITEVECTOR(idxmap->id_map);
+     } else if (const IndexHNSW* idxhnsw = dynamic_cast<const IndexHNSW*>(idx)) {
+         uint32_t h = dynamic_cast<const IndexHNSWFlat*>(idx) ? fourcc("IHNf")
+@@ -982,7 +982,7 @@ static void write_binary_multi_hash_map(
+     WRITEVECTOR(buf);
+ }
+ 
+-void write_index_binary(const IndexBinary* idx, IOWriter* f) {
++void write_index_binary(const IndexBinary* idx, IOWriter* f, int io_flags) {
+     if (const IndexBinaryFlat* idxf =
+                 dynamic_cast<const IndexBinaryFlat*>(idx)) {
+         uint32_t h = fourcc("IBxF");
+@@ -1021,7 +1021,12 @@ void write_index_binary(const IndexBinary* idx, IOWriter* f) {
+         }
+ 
+         write_HNSW(&idxhnsw->hnsw, f);
+-        write_index_binary(idxhnsw->storage, f);
++        if (io_flags & IO_FLAG_SKIP_STORAGE) {
++            uint32_t n4 = fourcc("null");
++            WRITE1(n4);
++        } else {
++            write_index_binary(idxhnsw->storage, f, io_flags);
++        }
+     } else if (
+             const IndexBinaryIDMap* idxmap =
+                     dynamic_cast<const IndexBinaryIDMap*>(idx)) {
+@@ -1031,7 +1036,7 @@ void write_index_binary(const IndexBinary* idx, IOWriter* f) {
+         // no need to store additional info for IndexIDMap2
+         WRITE1(h);
+         write_index_binary_header(idxmap, f);
+-        write_index_binary(idxmap->index, f);
++        write_index_binary(idxmap->index, f, io_flags);
+         WRITEVECTOR(idxmap->id_map);
+     } else if (
+             const IndexBinaryHash* idxh =
+@@ -1061,14 +1066,14 @@ void write_index_binary(const IndexBinary* idx, IOWriter* f) {
+     }
+ }
+ 
+-void write_index_binary(const IndexBinary* idx, FILE* f) {
++void write_index_binary(const IndexBinary* idx, FILE* f, int io_flags) {
+     FileIOWriter writer(f);
+-    write_index_binary(idx, &writer);
++    write_index_binary(idx, &writer, io_flags);
+ }
+ 
+-void write_index_binary(const IndexBinary* idx, const char* fname) {
++void write_index_binary(const IndexBinary* idx, const char* fname, int io_flags) {
+     FileIOWriter writer(fname);
+-    write_index_binary(idx, &writer);
++    write_index_binary(idx, &writer, io_flags);
+ }
+ 
+ } // namespace faiss
+diff --git a/faiss/index_io.h b/faiss/index_io.h
+index 79c013dff..4766190a9 100644
+--- a/faiss/index_io.h
++++ b/faiss/index_io.h
+@@ -37,9 +37,9 @@ void write_index(const Index* idx, const char* fname, int io_flags = 0);
+ void write_index(const Index* idx, FILE* f, int io_flags = 0);
+ void write_index(const Index* idx, IOWriter* writer, int io_flags = 0);
+ 
+-void write_index_binary(const IndexBinary* idx, const char* fname);
+-void write_index_binary(const IndexBinary* idx, FILE* f);
+-void write_index_binary(const IndexBinary* idx, IOWriter* writer);
++void write_index_binary(const IndexBinary* idx, const char* fname, int io_flags = 0);
++void write_index_binary(const IndexBinary* idx, FILE* f, int io_flags = 0);
++void write_index_binary(const IndexBinary* idx, IOWriter* writer, int io_flags = 0);
+ 
+ // The read_index flags are implemented only for a subset of index types.
+ const int IO_FLAG_READ_ONLY = 2;
+-- 
+2.50.1
+

--- a/remote_vector_index_builder/app/main.py
+++ b/remote_vector_index_builder/app/main.py
@@ -35,6 +35,7 @@ Dependencies:
     - app.storage: Storage implementations
     - app.utils: Utility functions and logging
 """
+
 from app.routes import build, status, heart_beat, get_jobs
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError

--- a/remote_vector_index_builder/core/common/models/__init__.py
+++ b/remote_vector_index_builder/core/common/models/__init__.py
@@ -10,7 +10,6 @@ from .index_build_parameters import IndexBuildParameters
 from .index_build_parameters import IndexSerializationMode
 from .vectors_dataset import VectorsDataset
 
-
 __all__ = [
     "SpaceType",
     "IndexBuildParameters",

--- a/remote_vector_index_builder/core/common/models/index_build_parameters.py
+++ b/remote_vector_index_builder/core/common/models/index_build_parameters.py
@@ -170,4 +170,5 @@ class IndexBuildParameters(BaseModel):
     data_type: DataType = DataType.FLOAT
     engine: Engine = Engine.FAISS
     index_parameters: IndexParameters = Field(default_factory=IndexParameters)
+    skip_stored_vectors: bool = False
     model_config = ConfigDict(extra="forbid")

--- a/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_index_hnsw_cagra_builder.py
+++ b/remote_vector_index_builder/core/common/models/index_builder/faiss/faiss_index_hnsw_cagra_builder.py
@@ -6,6 +6,7 @@
 # compatible open source license.
 
 import faiss
+import logging
 from dataclasses import dataclass
 from typing import Dict, Any
 from core.common.models.index_builder import (
@@ -17,6 +18,8 @@ from core.common.models.index_builder import (
 from remote_vector_index_builder.core.common.models.index_build_parameters import (
     DataType,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -37,6 +40,8 @@ class FaissIndexHNSWCagraBuilder(FaissCPUIndexBuilder):
     base_level_only: bool = True
 
     vector_dtype: DataType = DataType.FLOAT
+
+    skip_stored_vectors: bool = False
 
     @classmethod
     def from_dict(
@@ -69,7 +74,13 @@ class FaissIndexHNSWCagraBuilder(FaissCPUIndexBuilder):
             cpu_index.base_level_only = self.base_level_only
 
             # Copy GPU index to CPU index
-            faiss_gpu_build_index_output.gpu_index.copyTo(cpu_index)
+            if self.skip_stored_vectors:
+                logger.debug(
+                    "skip_stored_vectors=True: skipping vector storage during copyTo"
+                )
+                faiss_gpu_build_index_output.gpu_index.copyTo(cpu_index, True)
+            else:
+                faiss_gpu_build_index_output.gpu_index.copyTo(cpu_index)
 
             # Remove reference of GPU Index from the IndexIDMap
             faiss_gpu_build_index_output.index_id_map.index = None
@@ -104,7 +115,13 @@ class FaissIndexHNSWCagraBuilder(FaissCPUIndexBuilder):
             cpu_index.base_level_only = self.base_level_only
 
             # Convert GPU binary index to CPU binary index
-            faiss_gpu_build_index_output.gpu_index.copyTo(cpu_index)
+            if self.skip_stored_vectors:
+                logger.debug(
+                    "skip_stored_vectors=True: skipping vector storage during copyTo"
+                )
+                faiss_gpu_build_index_output.gpu_index.copyTo(cpu_index, True)
+            else:
+                faiss_gpu_build_index_output.gpu_index.copyTo(cpu_index)
 
             # Remove reference of GPU Index from the IndexBinaryIDMap
             faiss_gpu_build_index_output.index_id_map.index = None

--- a/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
+++ b/remote_vector_index_builder/core/index_builder/faiss/faiss_index_build_service.py
@@ -124,6 +124,7 @@ class FaissIndexBuildService(IndexBuildService):
                 "ef_search": index_build_parameters.index_parameters.algorithm_parameters.ef_search,
                 "ef_construction": index_build_parameters.index_parameters.algorithm_parameters.ef_construction,
                 "vector_dtype": index_build_parameters.data_type,
+                "skip_stored_vectors": index_build_parameters.skip_stored_vectors,
             }
             faiss_index_hnsw_cagra_builder = FaissIndexHNSWCagraBuilder.from_dict(
                 cpu_index_config_params
@@ -199,10 +200,21 @@ class FaissIndexBuildService(IndexBuildService):
             else:
                 # Otherwise, treat the output destination like a file path
                 writer = output_destination
+            io_flags = (
+                faiss.IO_FLAG_SKIP_STORAGE
+                if index_build_parameters.skip_stored_vectors
+                else 0
+            )
+            if io_flags:
+                logger.debug(
+                    "skip_stored_vectors=True: writing index with IO_FLAG_SKIP_STORAGE"
+                )
             if index_build_parameters.data_type != DataType.BINARY:
-                faiss.write_index(cpu_build_index_output.index_id_map, writer)
+                faiss.write_index(cpu_build_index_output.index_id_map, writer, io_flags)
             else:
-                faiss.write_index_binary(cpu_build_index_output.index_id_map, writer)
+                faiss.write_index_binary(
+                    cpu_build_index_output.index_id_map, writer, io_flags
+                )
             # Free memory taken by CPU Index
             cpu_build_index_output.cleanup()
             t2 = timer()

--- a/remote_vector_index_builder/core/tasks.py
+++ b/remote_vector_index_builder/core/tasks.py
@@ -31,6 +31,7 @@ One reason to call the default run_tasks function is that it optimizes the memor
 up the vectors after the index is built in memory
 
 """
+
 import logging
 import os
 import tempfile

--- a/test_remote_vector_index_builder/conftest.py
+++ b/test_remote_vector_index_builder/conftest.py
@@ -85,3 +85,45 @@ def aws_credentials():
     os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
     yield
     os.environ.pop("AWS_DEFAULT_REGION", None)
+
+
+@pytest.fixture
+def skip_stored_vectors_index_build_parameters():
+    """Create sample IndexBuildParameters with skip_stored_vectors=True for testing"""
+    return IndexBuildParameters(
+        container_name="testbucket",
+        vector_path="vec.knnvec",
+        doc_id_path="doc.knndid",
+        dimension=3,
+        doc_count=5,
+        index_parameters=IndexParameters(
+            space_type=SpaceType.INNERPRODUCT,
+            algorithm_parameters=AlgorithmParameters(
+                ef_construction=200, ef_search=200
+            ),
+        ),
+        data_type=DataType.FLOAT,
+        repository_type="s3",
+        skip_stored_vectors=True,
+    )
+
+
+@pytest.fixture
+def skip_stored_vectors_binary_index_build_parameters():
+    """Create sample binary IndexBuildParameters with skip_stored_vectors=True for testing"""
+    return IndexBuildParameters(
+        container_name="testbucket",
+        vector_path="vec.knnvec",
+        doc_id_path="doc.knndid",
+        dimension=24,
+        doc_count=5,
+        index_parameters=IndexParameters(
+            space_type=SpaceType.INNERPRODUCT,
+            algorithm_parameters=AlgorithmParameters(
+                ef_construction=200, ef_search=200
+            ),
+        ),
+        data_type=DataType.BINARY,
+        repository_type="s3",
+        skip_stored_vectors=True,
+    )

--- a/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_index_hnsw_cagra_builder.py
+++ b/test_remote_vector_index_builder/test_core/common/models/index_builder/faiss/test_faiss_index_hnsw_cagra_builder.py
@@ -94,3 +94,105 @@ class TestFaissIndexHNSWCagraBuilder:
             )
         assert "Failed to convert GPU index to CPU index" in str(exc_info.value)
         assert "Simulated copy error" in str(exc_info.value)
+
+    def test_skip_stored_vectors_passes_skip_storage(
+        self, mock_gpu_index, mock_index_id_map
+    ):
+        """Test that skip_stored_vectors=True passes skip_storage=True to copyTo"""
+        builder = FaissIndexHNSWCagraBuilder(skip_stored_vectors=True)
+
+        copy_calls = []
+        original_copyTo = mock_gpu_index.copyTo
+
+        def tracking_copyTo(cpu_index, skip_storage=False):
+            copy_calls.append(skip_storage)
+            return original_copyTo(cpu_index, skip_storage)
+
+        mock_gpu_index.copyTo = tracking_copyTo
+
+        builder.convert_gpu_to_cpu_index(
+            FaissGpuBuildIndexOutput(
+                gpu_index=mock_gpu_index, index_id_map=mock_index_id_map
+            )
+        )
+
+        assert len(copy_calls) == 1
+        assert copy_calls[0] is True
+
+    def test_skip_stored_vectors_false_passes_skip_storage_false(
+        self, default_builder, mock_gpu_index, mock_index_id_map
+    ):
+        """Test that skip_stored_vectors=False (default) passes skip_storage=False to copyTo"""
+        copy_calls = []
+        original_copyTo = mock_gpu_index.copyTo
+
+        def tracking_copyTo(cpu_index, skip_storage=False):
+            copy_calls.append(skip_storage)
+            return original_copyTo(cpu_index, skip_storage)
+
+        mock_gpu_index.copyTo = tracking_copyTo
+
+        default_builder.convert_gpu_to_cpu_index(
+            FaissGpuBuildIndexOutput(
+                gpu_index=mock_gpu_index, index_id_map=mock_index_id_map
+            )
+        )
+
+        assert len(copy_calls) == 1
+        assert copy_calls[0] is False
+
+    def test_binary_skip_stored_vectors_passes_skip_storage(self):
+        """Test that skip_stored_vectors=True passes skip_storage=True to binary copyTo"""
+        from core.common.models.index_build_parameters import DataType
+
+        builder = FaissIndexHNSWCagraBuilder(
+            skip_stored_vectors=True, vector_dtype=DataType.BINARY
+        )
+
+        mock_gpu_binary_index = faiss.GpuIndexBinaryCagra()
+        mock_binary_id_map = faiss.IndexBinaryIDMap()
+
+        copy_calls = []
+        original_copyTo = mock_gpu_binary_index.copyTo
+
+        def tracking_copyTo(cpu_index, skip_storage=False):
+            copy_calls.append(skip_storage)
+            return original_copyTo(cpu_index, skip_storage)
+
+        mock_gpu_binary_index.copyTo = tracking_copyTo
+
+        builder.convert_gpu_to_cpu_index(
+            FaissGpuBuildIndexOutput(
+                gpu_index=mock_gpu_binary_index, index_id_map=mock_binary_id_map
+            )
+        )
+
+        assert len(copy_calls) == 1
+        assert copy_calls[0] is True
+
+    def test_binary_skip_stored_vectors_false_does_not_skip_storage(self):
+        """Test that skip_stored_vectors=False (default) does not skip storage for binary copyTo"""
+        from core.common.models.index_build_parameters import DataType
+
+        builder = FaissIndexHNSWCagraBuilder(vector_dtype=DataType.BINARY)
+
+        mock_gpu_binary_index = faiss.GpuIndexBinaryCagra()
+        mock_binary_id_map = faiss.IndexBinaryIDMap()
+
+        copy_calls = []
+        original_copyTo = mock_gpu_binary_index.copyTo
+
+        def tracking_copyTo(cpu_index, skip_storage=False):
+            copy_calls.append(skip_storage)
+            return original_copyTo(cpu_index, skip_storage)
+
+        mock_gpu_binary_index.copyTo = tracking_copyTo
+
+        builder.convert_gpu_to_cpu_index(
+            FaissGpuBuildIndexOutput(
+                gpu_index=mock_gpu_binary_index, index_id_map=mock_binary_id_map
+            )
+        )
+
+        assert len(copy_calls) == 1
+        assert copy_calls[0] is False

--- a/test_remote_vector_index_builder/test_core/conftest.py
+++ b/test_remote_vector_index_builder/test_core/conftest.py
@@ -74,7 +74,7 @@ class MockGpuIndexCagra:
     def is_deleted(self):
         return _deletion_tracker.is_deleted(self.id)
 
-    def copyTo(self, cpu_index):
+    def copyTo(self, cpu_index, skip_storage=False):
         """Mock implementation of copyTo method"""
         if not isinstance(cpu_index, MockIndexHNSWCagra):
             raise TypeError("Target must be IndexHNSWCagra")
@@ -99,7 +99,7 @@ class MockGpuIndexBinaryCagra:
     def is_deleted(self):
         return _deletion_tracker.is_deleted(self.id)
 
-    def copyTo(self, cpu_index):
+    def copyTo(self, cpu_index, skip_storage=False):
         """Mock implementation of copyTo method"""
         if not isinstance(cpu_index, MockIndexBinaryHNSWCagra):
             raise TypeError("Target must be MockIndexBinaryHNSWCagra")
@@ -253,6 +253,9 @@ class FaissMock(ModuleType):
         self.Float16 = Mock()
         self.Int8 = Mock()
 
+        # Constants
+        self.IO_FLAG_SKIP_STORAGE = 1
+
         # Enums
         self.graph_build_algo_IVF_PQ = 0
         self.graph_build_algo_NN_DESCENT = 1
@@ -282,7 +285,7 @@ class FaissMock(ModuleType):
             raise TypeError("Target must be GpuIndexBinaryCagra")
         return self.IndexBinaryHNSW()
 
-    def _write_index_binary(self, index, output_destination):
+    def _write_index_binary(self, index, output_destination, io_flags=0):
         if not isinstance(index, MockIndexBinaryIDMap):
             raise TypeError("Target must be IndexBinaryIDMap")
         if isinstance(output_destination, str):
@@ -299,7 +302,7 @@ class FaissMock(ModuleType):
         else:
             raise TypeError("Unsupported output destination")
 
-    def _write_index(self, index, output_destination):
+    def _write_index(self, index, output_destination, io_flags=0):
         if not index:
             raise ValueError("Index cannot be None")
         if isinstance(output_destination, str):

--- a/test_remote_vector_index_builder/test_core/index_builder/test_faiss_index_build_service.py
+++ b/test_remote_vector_index_builder/test_core/index_builder/test_faiss_index_build_service.py
@@ -16,6 +16,7 @@ from core.common.models.index_builder import CagraGraphBuildAlgo
 from core.common.models.index_builder.faiss import FaissGPUIndexCagraBuilder
 from core.index_builder.faiss.faiss_index_build_service import FaissIndexBuildService
 from core.index_builder.index_builder_utils import calculate_ivf_pq_n_lists
+from core.common.models.index_builder.faiss import FaissIndexHNSWCagraBuilder
 
 
 class TestFaissIndexBuildService:
@@ -291,3 +292,124 @@ class TestFaissIndexBuildService:
                 )
 
             assert "Write failed" in str(exc_info.value)
+
+    def test_build_index_skip_stored_vectors(
+        self,
+        service,
+        vectors_dataset,
+        skip_stored_vectors_index_build_parameters,
+        tmp_path,
+    ):
+        """Test that skip_stored_vectors=True is passed through to CPU index builder"""
+        with patch(
+            "core.common.models.index_builder.faiss.FaissGPUIndexCagraBuilder.from_dict"
+        ) as mock_gpu_from_dict, patch(
+            "core.common.models.index_builder.faiss.FaissIndexHNSWCagraBuilder.from_dict"
+        ) as mock_cpu_from_dict:
+            from core.common.models.index_builder.faiss import FaissGPUIndexCagraBuilder
+
+            mock_gpu_from_dict.return_value = FaissGPUIndexCagraBuilder()
+            mock_cpu_from_dict.return_value = FaissIndexHNSWCagraBuilder(
+                skip_stored_vectors=True
+            )
+
+            service.build_index(
+                skip_stored_vectors_index_build_parameters, vectors_dataset
+            )
+
+            cpu_call_args = mock_cpu_from_dict.call_args[0][0]
+            assert cpu_call_args["skip_stored_vectors"] is True
+
+    def test_build_binary_index_skip_stored_vectors(
+        self,
+        service,
+        binary_vectors_dataset,
+        skip_stored_vectors_binary_index_build_parameters,
+        tmp_path,
+    ):
+        """Test that skip_stored_vectors=True is passed through to CPU index builder for binary"""
+        with patch(
+            "core.common.models.index_builder.faiss.FaissGPUIndexCagraBuilder.from_dict"
+        ) as mock_gpu_from_dict, patch(
+            "core.common.models.index_builder.faiss.FaissIndexHNSWCagraBuilder.from_dict"
+        ) as mock_cpu_from_dict:
+            from core.common.models.index_builder.faiss import FaissGPUIndexCagraBuilder
+
+            mock_gpu_from_dict.return_value = FaissGPUIndexCagraBuilder()
+            mock_cpu_from_dict.return_value = FaissIndexHNSWCagraBuilder(
+                skip_stored_vectors=True, vector_dtype=DataType.BINARY
+            )
+
+            service.build_index(
+                skip_stored_vectors_binary_index_build_parameters,
+                binary_vectors_dataset,
+            )
+
+            cpu_call_args = mock_cpu_from_dict.call_args[0][0]
+            assert cpu_call_args["skip_stored_vectors"] is True
+
+    def test_write_cpu_index_skip_stored_vectors_passes_io_flag(
+        self,
+        service,
+        vectors_dataset,
+        skip_stored_vectors_index_build_parameters,
+        tmp_path,
+    ):
+        """Test that write_cpu_index passes IO_FLAG_SKIP_STORAGE when skip_stored_vectors=True"""
+        cpu_index_output = service.build_index(
+            skip_stored_vectors_index_build_parameters, vectors_dataset
+        )
+
+        write_calls = []
+        original_write = faiss.write_index
+
+        def tracking_write(index, writer, io_flags=0):
+            write_calls.append(io_flags)
+            return original_write(index, writer)
+
+        faiss.write_index = tracking_write
+        try:
+            output_path = str(tmp_path / "output.index")
+            service.write_cpu_index(
+                cpu_index_output,
+                skip_stored_vectors_index_build_parameters,
+                IndexSerializationMode.DISK,
+                output_path,
+            )
+            assert len(write_calls) == 1
+            assert write_calls[0] == faiss.IO_FLAG_SKIP_STORAGE
+        finally:
+            faiss.write_index = original_write
+
+    def test_write_binary_cpu_index_skip_stored_vectors_passes_io_flag(
+        self,
+        service,
+        binary_vectors_dataset,
+        skip_stored_vectors_binary_index_build_parameters,
+        tmp_path,
+    ):
+        """Test that write_cpu_index passes IO_FLAG_SKIP_STORAGE for binary when skip_stored_vectors=True"""
+        cpu_index_output = service.build_index(
+            skip_stored_vectors_binary_index_build_parameters, binary_vectors_dataset
+        )
+
+        write_calls = []
+        original_write = faiss.write_index_binary
+
+        def tracking_write(index, writer, io_flags=0):
+            write_calls.append(io_flags)
+            return original_write(index, writer)
+
+        faiss.write_index_binary = tracking_write
+        try:
+            output_path = str(tmp_path / "output.index")
+            service.write_cpu_index(
+                cpu_index_output,
+                skip_stored_vectors_binary_index_build_parameters,
+                IndexSerializationMode.DISK,
+                output_path,
+            )
+            assert len(write_calls) == 1
+            assert write_calls[0] == faiss.IO_FLAG_SKIP_STORAGE
+        finally:
+            faiss.write_index_binary = original_write


### PR DESCRIPTION
### Description
This PR introduces a `skip_stored_vectors` parameter to the remote vector index builder. When `skip_stored_vectors`: `True`, the remote vector index builder skips attaching the flat vector storage when converting the CAGRA graph to HNSW graph. This change allows the remote vector index builder to only upload the graph structure to the remote repository, and leaves it up to the k-NN plugin to stitch the graph and flat vectors back together at indexing or search time.There are three main benefits to this:

1. Make k-NN the owner of the flat vector storage. This makes it easier to make updates to the storage format in the future, without touching the RVIB
2. Reduce the memory pressure on the RVIB. Flat vectors can be very large, and take up almost 1/2 the total CPU memory required by the worker. 
3. Optimize the graph upload. Without the flat vectors, the graph upload is much faster


The k-NN plugin must send `skip_stored_vectors`: `True` in the build request, in order to trigger this behavior. For backwards compatibility with older versions of k-NN, this parameter defaults to `False` if not present. 

I opened an issue in faiss to try and get this changed merged upstream: https://github.com/facebookresearch/faiss/issues/4931 - ideally we have it merged upstream instead of relying on a patch.

To begin with, this change will be integrated with the quantization flow on k-NN. We are also doing something different here for quantization: instead of sending the quantized vectors from k-NN to RVIB, we send the fp32 vectors to RVIB. Then RVIB sends back the graph structure, and k-NN will stitch together the quantized vectors on the data node with the graph. The reason for this is to support 1 bit SQ quantization flat vector storage format in k-NN - `CAGRA` does not currently support this custom storage format, so we need to decouple the graph build with the flat vector storage format on the RVIB. This helps ensure k-NN owns the flat vector storage format, although it increase the memory pressure on the worker, and require longer download times. 

I will soon raise a PR on the k-NN side that supports stitching the graph back together with the storage, and link it here. 


### Testing

Unit tests. 

I also did a manual test where i spun up a local instance of the API docker container, and triggered a remote build request with the following script:

```
curl -XPOST "http://0.0.0.0:80/_build" \
-H 'Content-Type: application/json' \
-d '
    {
        "repository_type": "s3",
        "container_name": "testbucket-rchital",
        "vector_path": "test-data/more-data/1536_2000000.knnvec",
        "doc_id_path": "test-data/more-data/1536_2000000_ids.knndid",
        "dimension": "1536",
        "doc_count": "2000000",
        "skip_stored_vectors": true
    }
'
```

This script uses a 2 mil x 1536 random vector dataset in my local s3 bucket. I verified the build was successful, also monitored the CPU memory using the following script: https://github.com/opensearch-project/remote-vector-index-builder/blob/main/scripts/monitor_memory.py . The peak CPU memory was 13 GB - well below the 25 GB peak usage observed when `skip_stored_vectors`: `false`.

I also tested without the `skip_stored_vectors` flag to test for backwards compatibility. 

```
curl -XPOST "http://0.0.0.0:80/_build" \
-H 'Content-Type: application/json' \
-d '
    {
        "repository_type": "s3",
        "container_name": "testbucket-rchital",
        "vector_path": "test-data/more-data/1536_2000000.knnvec",
        "doc_id_path": "test-data/more-data/1536_2000000_ids.knndid",
        "dimension": "1536",
        "doc_count": "2000000"
    }
'
```

I verified this is continuing to work as expected. The integration test CIs also don't use this flag, and are passing, so we can be confident the addition of this new parameter to the API won't break backwards compatibility. 

### Issues Resolved
Partially for: https://github.com/opensearch-project/k-NN/issues/3274

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).