### PR TITLE
Pin localstack version to 4.14 to avoid upgrade account requirements

### DIFF
--- a/e2e/api/docker-compose.yml
+++ b/e2e/api/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   localstack:
     container_name: localstack-main
-    image: localstack/localstack
+    image: localstack/localstack:4.14
     ports:
       - "4566:4566"
     environment:


### PR DESCRIPTION
### Description
Pin the version of LocalStack to 4.14 as newer versions require an account.

Ref: https://news.ycombinator.com/item?id=47493657
Related k-NN fix: https://github.com/opensearch-project/k-NN/pull/3204

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).