### PR TITLE
Add issues write permission to untriaged label workflow

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, reopened, transferred]
 
+permissions:
+  issues: write
+
 jobs:
   apply-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -11,7 +11,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.addLabels({


### PR DESCRIPTION
### Description
Add `permissions: issues: write` to the `add-untriaged.yml` workflow to fix 403 "Resource not accessible by integration" error when applying the 'untriaged' label to issues.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).