### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -5,10 +5,10 @@ jobs:
   linkchecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@master
+        uses: lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0 # master
         with:
           args: --accept=200,403,429 "./**/*.md" "./**/*.txt"
         env:

--- a/.github/workflows/publish_faiss_base_image.yml
+++ b/.github/workflows/publish_faiss_base_image.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
             submodules: 'recursive'
             path: 'rvib'
@@ -33,7 +33,7 @@ jobs:
             docker build  -f ./base_image/build_scripts/Dockerfile . -t opensearchstaging/remote-vector-index-builder:faiss-base-snapshot
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
             role-to-assume: ${{ secrets.REMOTE_VECTOR_DOCKER_ROLE }}
             aws-region: us-east-1
@@ -46,7 +46,7 @@ jobs:
             echo "dockerhub-password=$DOCKERHUB_PASSWORD" >> $GITHUB_OUTPUT
           
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
             username: ${{ secrets.REMOTE_VECTOR_DOCKER_USERNAME }}
             password: ${{ steps.retrieve-values.outputs.dockerhub-password }}

--- a/.github/workflows/publish_remote_api_image.yml
+++ b/.github/workflows/publish_remote_api_image.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Docker Image
         run : |
           docker build  -f ./remote_vector_index_builder/app/Dockerfile . -t opensearchstaging/remote-vector-index-builder:api-snapshot
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.REMOTE_VECTOR_DOCKER_ROLE }}
           aws-region: us-east-1
@@ -49,7 +49,7 @@ jobs:
           echo "dockerhub-password=$DOCKERHUB_PASSWORD" >> $GITHUB_OUTPUT
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.REMOTE_VECTOR_DOCKER_USERNAME }}
           password: ${{ steps.retrieve-values.outputs.dockerhub-password }}

--- a/.github/workflows/publish_remote_core_image.yml
+++ b/.github/workflows/publish_remote_core_image.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Docker Image
         run : |
           docker build  -f ./remote_vector_index_builder/core/Dockerfile . -t opensearchstaging/remote-vector-index-builder:core-snapshot
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.REMOTE_VECTOR_DOCKER_ROLE }}
           aws-region: us-east-1
@@ -49,7 +49,7 @@ jobs:
           echo "dockerhub-password=$DOCKERHUB_PASSWORD" >> $GITHUB_OUTPUT
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.REMOTE_VECTOR_DOCKER_USERNAME }}
           password: ${{ steps.retrieve-values.outputs.dockerhub-password }}

--- a/.github/workflows/publish_remote_vector_version_images.yml
+++ b/.github/workflows/publish_remote_vector_version_images.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
             submodules: 'recursive'
 
@@ -117,7 +117,7 @@ jobs:
 
       # https://github.com/trstringer/manual-approval
       - name: Get Manual Workflow Approval
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
         with: 
           secret: ${{ github.TOKEN }}
           approvers: ${{ steps.get_approvers.outputs.approvers }}
@@ -127,7 +127,7 @@ jobs:
           issue-body: 'Please approve or deny publishing Remote-Vector-Index-Builder Version v${{ steps.get-version.outputs.version }} Images to opensearchstaging **COMMIT**: ${{ github.sha }}.'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.REMOTE_VECTOR_DOCKER_ROLE }}
           aws-region: us-east-1
@@ -140,7 +140,7 @@ jobs:
           echo "dockerhub-password=$DOCKERHUB_PASSWORD" >> $GITHUB_OUTPUT
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.REMOTE_VECTOR_DOCKER_USERNAME }}
           password: ${{ steps.retrieve-values.outputs.dockerhub-password }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       steps:
         - name: Checkout code
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           
         - name: Get Approvers
           id: get_approvers
@@ -28,7 +28,7 @@ jobs:
             echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
 
         - name: Get Manual Workflow Approval
-          uses: trstringer/manual-approval@v1
+          uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
           with: 
             secret: ${{ github.TOKEN }}
             approvers: ${{ steps.get_approvers.outputs.approvers }}
@@ -44,7 +44,7 @@ jobs:
           run: | 
             echo 'version: ${{ github.event.inputs.version }}' > release-description.yaml
         - name: Create tag
-          uses: actions/github-script@v6
+          uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
           with:
             github-token: ${{ github.TOKEN }}
             script: |
@@ -55,7 +55,7 @@ jobs:
                   sha: context.sha
                 })
         - name: Draft release
-          uses: softprops/action-gh-release@v1
+          uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
           with:
             draft: true
             name: '${{ github.event.inputs.version }}'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
         # https://github.com/actions/checkout?tab=readme-ov-file#usage
         - name: Checkout code
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           with:
             # Note this is done for folder specific checkouts, reduce CI memory load
             sparse-checkout: |
@@ -33,7 +33,7 @@ jobs:
               test_remote_vector_index_builder
               e2e
         - name: Setup Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
           with:
             python-version: '3.11'
 

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Docker Image
         run : |


### PR DESCRIPTION
### Description

Pin all GitHub Action tag references to their corresponding commit SHAs.

Tags are mutable references that can be force-pushed to point to different commits, making them vulnerable to supply chain attacks. Commit SHAs are immutable and guarantee that the exact reviewed code is executed in CI workflows. This change pins all third-party actions to their current commit SHAs to prevent potential tampering.