### PR TITLE
Tune S3 transfer concurrency for smaller GPU instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For more information, see [opensearch.org](https://opensearch.org/).
 
 ## Project Style Guidelines
 
-The [OpenSearch Project style guidelines](https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md) and [OpenSearch terms](https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md) documents provide style standards and terminology to be observed when creating OpenSearch Project content.
+The [OpenSearch Project style guidelines](https://github.com/opensearch-project/documentation-website/blob/main/style-guide/STYLE_GUIDE.md) and [OpenSearch terms](https://github.com/opensearch-project/documentation-website/blob/main/style-guide/TERMS.md) documents provide style standards and terminology to be observed when creating OpenSearch Project content.
 
 ## Code of Conduct
 

--- a/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
+++ b/remote_vector_index_builder/core/object_store/s3/s3_object_store.py
@@ -26,24 +26,34 @@ from core.object_store.s3.s3_object_store_config import S3ClientConfig
 logger = logging.getLogger(__name__)
 
 
-def get_cpus(factor: float) -> int:
-    """Get the number of CPUs to use for s3 upload or download operation
+# Minimum S3 transfer concurrency (max_concurrency). S3 transfers are
+# network-bound rather than CPU-bound, so a pure cpu_count * factor starves
+# small instances (e.g. 0.625 * 4 vCPU = 2 threads on g6.xlarge). A
+# download/upload benchmark sweep on g6.xlarge and g6.2xlarge showed throughput
+# plateaus around 8 threads for those hosts. Larger instances keep scaling via
+# the factor (which already exceeds this floor), so their behavior is unchanged.
+MIN_TRANSFER_CONCURRENCY = 8
+
+
+def get_transfer_concurrency(factor: float) -> int:
+    """Get the max_concurrency to use for an s3 upload or download operation.
 
     Args:
-        factor (float): The factor to multiply total cpu count by
+        factor (float): The factor to multiply total cpu count by.
 
     Returns:
-        int: The number of CPUs that will be used for s3 upload or download
+        int: The number of concurrent threads boto3 will use for the transfer.
 
-    The cpu count is rounded down to the nearest integer
+    Scales as floor(cpu_count * factor) but is floored at
+    MIN_TRANSFER_CONCURRENCY so small instances are not starved.
     """
 
     # according to mypy, os.cpu_count can be None
     # if it is none, then default to 1 thread
     cpu_count = os.cpu_count()
-    if cpu_count:
-        return max(1, math.floor(cpu_count * factor))
-    return 1
+    if not cpu_count:
+        return 1
+    return max(MIN_TRANSFER_CONCURRENCY, math.floor(cpu_count * factor))
 
 
 @cache
@@ -124,14 +134,14 @@ class S3ObjectStore(ObjectStore):
 
         self.DEFAULT_DOWNLOAD_TRANSFER_CONFIG = {
             "multipart_chunksize": 50 * 1024 * 1024,  # 50MB
-            "max_concurrency": get_cpus(factor=0.625),
+            "max_concurrency": get_transfer_concurrency(factor=0.625),
             "multipart_threshold": 50 * 1024 * 1024,  # 50MB
             "io_chunksize": sys.maxsize,
         }
 
         self.DEFAULT_UPLOAD_TRANSFER_CONFIG = {
             "multipart_chunksize": 50 * 1024 * 1024,  # 50MB
-            "max_concurrency": get_cpus(factor=0.5),
+            "max_concurrency": get_transfer_concurrency(factor=0.5),
             "multipart_threshold": 50 * 1024 * 1024,  # 50MB
         }
 

--- a/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
+++ b/test_remote_vector_index_builder/test_core/test_object_store/test_s3/test_s3_object_store.py
@@ -13,7 +13,11 @@ from botocore.config import Config
 from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ClientError
 from core.common.exceptions import BlobError
-from core.object_store.s3.s3_object_store import S3ObjectStore, get_boto3_client
+from core.object_store.s3.s3_object_store import (
+    S3ObjectStore,
+    get_boto3_client,
+    get_transfer_concurrency,
+)
 from core.object_store.s3.s3_object_store_config import S3ClientConfig
 
 
@@ -52,6 +56,37 @@ def bytes_buffer():
     bytes_buffer = BytesIO()
     yield bytes_buffer
     bytes_buffer.close()
+
+
+@pytest.mark.parametrize(
+    "cpu_count,factor,expected",
+    [
+        (None, 0.625, 1),  # cpu_count unavailable -> 1 thread
+        (1, 0.625, 8),  # tiny host -> floored to MIN_TRANSFER_CONCURRENCY
+        (4, 0.625, 8),  # g6.xlarge download -> floored (floor(4 * 0.625) = 2)
+        (4, 0.5, 8),  # g6.xlarge upload -> floored
+        (8, 0.625, 8),  # g6.2xlarge download -> floored (floor(8 * 0.625) = 5)
+        (8, 0.5, 8),  # g6.2xlarge upload -> floored (floor(8 * 0.5) = 4)
+        (16, 0.625, 10),  # g6.4xlarge download -> floor(16 * 0.625), above floor
+        (16, 0.5, 8),  # g6.4xlarge upload -> floor(16 * 0.5), equals floor
+        (48, 0.625, 30),  # g6.12xlarge download -> floor(48 * 0.625), unchanged
+    ],
+)
+def test_get_transfer_concurrency(cpu_count, factor, expected):
+    with patch("os.cpu_count", return_value=cpu_count):
+        assert get_transfer_concurrency(factor) == expected
+
+
+def test_default_transfer_concurrency_propagates_to_configs(index_build_parameters):
+    # On a g6.2xlarge (8 vCPU) with no overrides, both defaults hit the floor (8).
+    with patch("core.object_store.s3.s3_object_store.get_boto3_client"):
+        with patch("os.cpu_count", return_value=8):
+            store = S3ObjectStore(
+                index_build_parameters,
+                {"s3_client_config": S3ClientConfig(region_name="us-east-1")},
+            )
+            assert store.download_transfer_config["max_concurrency"] == 8
+            assert store.upload_transfer_config["max_concurrency"] == 8
 
 
 def test_get_boto3_client():


### PR DESCRIPTION
### Description
s3 transfer concurrency benchmarking was done as part of this issue: https://github.com/opensearch-project/remote-vector-index-builder/issues/23. Based on those benchmarking results, I made the number of threads used for download = `0.625 x vcpu_count` and upload = `0.5 x vcpu_count`. This works well for 4xlarge and larger instances, but we found out that it gives worse performance for smaller instances that have less vcpus (such as xlarge and 2xlarge). More details for the xlarge and 2xlarge performance are given here: https://github.com/opensearch-project/remote-vector-index-builder/issues/141

This PR changes the thread count for xlarge and 2xlarge for upload and download such that both use 8 threads. 

***With this new thread count, the download and upload performance for xlarge and 2xlarge is now comparable, and should be approximately be 1.5-2x better than before***. 

### Benchmarking 
For benchmarking on xlarge and 2xlarge, I used the following datasets: 

| Dataset | dim | doc_count | size (GiB)
|---|---|---|---|
| sift | 128 | 1M | 0.48 |
| ms-marco-384 | 384 | 1M | 1.43 |
| cohere-768-ip | 768 | 1M | 2.86 |
| open-ai-1536 | 1536 | 1M | 5.72 |

Then, I used the testing scripts in my local fork: https://github.com/rchitale7/remote-vector-index-builder/tree/add-benchmark-scripts/new-benchmark-scripts to test the impact of various download and upload thread count factors to download and upload performance. I tested with a g6.xlarge and g6.2xlarge instance in us-west-2. These were the values I tested:

  | Factor | xl (4 vCPU) download | xl (4 vCPU) upload | 2xl (8 vCPU) download | 2xl (8 vCPU) upload |
  |---|---|---|---|---|
  | baseline (0.625 download / 0.5 upload) | 2 | 2 | 5 | 4 |
  | factor 1.0 | 4 | 4 | 8 | 8 |
  | factor 1.5 | 6 | 6 | 12 | 12 |
  | factor 2.0 | 8 | 8 | 16 | 16 |
  | factor 2.5 | 10 | 10 | 20 | 20 |
  | factor 3.0 | 12 | 12 | 24 | 24 |

The baseline is the current state, which is `0.625 x vcpu_count` for downloads and `0.5 x vcpu_count` for uploads. xlarge machines have 4 vcpus, while 2xlarge have 8 vcpus. 

For each factor I built a separate Docker image of the index builder with that factor applied to both the download and upload thread counts, then ran every image through the benchmark harness (https://github.com/rchitale7/remote-vector-index-builder/blob/add-benchmark-scripts/new-benchmark-scripts/factor-sweep/run_factor_sweep.sh). The harness builds an index per dataset through the API container and parses the per-stage download and upload times from the container's debug logs. 

Each image was run 5 times across the full dataset list, and the values below are the median (p50) of the 5 recorded download (and upload) times for each dataset.

  ### Results — median (p50) transfer time in seconds (bold = fastest in each row)

  **xl (4 vCPU) — download**

  | Dataset | baseline | factor 1.0 | factor 1.5 | factor 2.0 | factor 2.5 | factor 3.0 |
  |---|---|---|---|---|---|---|
  | sift | 4.27 | 2.19 | 1.87 | **1.79** | 2.08 | 1.86 |
  | ms-marco-384 | 11.50 | 5.73 | 4.54 | **4.44** | 5.03 | 5.08 |
  | cohere-768-ip | 21.09 | 10.54 | **8.38** | 8.88 | 10.23 | 9.47 |
  | open-ai-1536 | 45.32 | 20.35 | 16.37 | **15.90** | 17.33 | 18.09 |

  **xl (4 vCPU) — upload**

  | Dataset | baseline | factor 1.0 | factor 1.5 | factor 2.0 | factor 2.5 | factor 3.0 |
  |---|---|---|---|---|---|---|
  | sift | 3.83 | 2.33 | 1.79 | **1.71** | 1.82 | 1.80 |
  | ms-marco-384 | 8.68 | 4.72 | 3.85 | **3.63** | 3.85 | 3.92 |
  | cohere-768-ip | 16.15 | 8.59 | 6.64 | **6.63** | 6.90 | 6.90 |
  | open-ai-1536 | 31.18 | 16.13 | **12.72** | 12.78 | 13.03 | 13.08 |

  **2xl (8 vCPU) — download**

  | Dataset | baseline | factor 1.0 | factor 1.5 | factor 2.0 | factor 2.5 | factor 3.0 |
  |---|---|---|---|---|---|---|
  | sift | 2.29 | 1.92 | 1.76 | 1.59 | 1.82 | **1.56** |
  | ms-marco-384 | 6.02 | 4.03 | **3.97** | 4.01 | 4.10 | 4.42 |
  | cohere-768-ip | 10.69 | 7.51 | **7.20** | 7.49 | 7.56 | 7.88 |
  | open-ai-1536 | 21.70 | **13.76** | 13.79 | 14.35 | 14.30 | 14.84 |

  **2xl (8 vCPU) — upload**

  | Dataset | baseline | factor 1.0 | factor 1.5 | factor 2.0 | factor 2.5 | factor 3.0 |
  |---|---|---|---|---|---|---|
  | sift | 2.34 | **1.52** | 1.55 | 1.53 | 1.56 | 1.59 |
  | ms-marco-384 | 4.73 | **3.02** | 3.14 | 3.13 | 3.15 | 3.20 |
  | cohere-768-ip | 8.68 | **5.39** | 5.48 | 5.52 | 5.55 | 5.67 |
  | open-ai-1536 | 16.27 | **10.01** | 10.09 | 10.03 | 10.15 | 10.21 |

### Analysis

For both instances and both download and upload, the largest gains come from `baseline → factor 1.0`; beyond 1.0, the curve begins to flatten. According to the data, factor = 2.0 gives the best upload and download performance for xlarge, while factor = 1.0 or 1.5 gives the best upload and download performance for 2xlarge. If we use factor = 1.0 for 2xlarge and factor = 2.0 for xlarge, that gives us 8 threads for both. So, to keep things simple, I'm setting 8 threads as the floor concurrency in this PR


### Issues Resolved
Resolves https://github.com/opensearch-project/remote-vector-index-builder/issues/141

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).