### PR TITLE
Fix the CIs for publishing base, core, and app images

### DIFF
--- a/.github/workflows/publish_faiss_base_image.yml
+++ b/.github/workflows/publish_faiss_base_image.yml
@@ -12,6 +12,12 @@ permissions:
   id-token: write
   contents: read
 
+# Serialize image-publishing pipelines so a base-image cascade and a core/app
+# push can never publish out of order or race for the shared snapshot tags.
+concurrency:
+  group: publish-snapshot-images
+  cancel-in-progress: false
+
 jobs:
   build-and-publish-faiss-base-image:
     name: Build and Publish Remote-Vector-Index-Builder Faiss Base Snapshot Image
@@ -28,9 +34,12 @@ jobs:
             path: 'rvib'
 
       - name: Build Docker Image
+        # --pull forces Docker to fetch the latest nvidia/cuda base image from
+        # the registry instead of reusing a stale, locally-cached layer on the
+        # self-hosted runner
         run : |
             cd rvib
-            docker build  -f ./base_image/build_scripts/Dockerfile . -t opensearchstaging/remote-vector-index-builder:faiss-base-snapshot
+            docker build --pull -f ./base_image/build_scripts/Dockerfile . -t opensearchstaging/remote-vector-index-builder:faiss-base-snapshot
       
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4

--- a/.github/workflows/publish_remote_api_image.yml
+++ b/.github/workflows/publish_remote_api_image.yml
@@ -1,13 +1,11 @@
 name: Build and Publish Remote-Vector-Index-Builder API Image to Docker
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'remote_vector_index_builder/app/**'
-      - '.github/workflows/publish_remote_api_image.yml'
-
+  # NOTE: This workflow is intentionally NOT triggered directly on push.
+  # The API image is built via the base -> core -> api cascade started by
+  # publish_remote_core_image.yml (which triggers on both core/** and app/**
+  # changes). This guarantees the API image is always built on top of a
+  # freshly-published core image, in a single strictly-ordered pipeline.
   workflow_call: # enables workflow to be reused
     secrets:
       REMOTE_VECTOR_DOCKER_USERNAME:
@@ -32,8 +30,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Docker Image
+        # --pull forces Docker to fetch the latest core-snapshot base image from
+        # the registry instead of reusing a stale, locally-cached layer on the
+        # self-hosted runner
         run : |
-          docker build  -f ./remote_vector_index_builder/app/Dockerfile . -t opensearchstaging/remote-vector-index-builder:api-snapshot
+          docker build --pull -f ./remote_vector_index_builder/app/Dockerfile . -t opensearchstaging/remote-vector-index-builder:api-snapshot
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4

--- a/.github/workflows/publish_remote_core_image.yml
+++ b/.github/workflows/publish_remote_core_image.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - main
     paths:
+      # This workflow owns building both the core image and (via the cascade
+      # below) the api image. app/** is included here so that app-only changes
+      # rebuild core and then api in a single ordered pipeline, rather than via
+      # a separate, unordered api workflow. 
       - 'remote_vector_index_builder/core/**'
+      - 'remote_vector_index_builder/app/**'
       - '.github/workflows/publish_remote_core_image.yml'
+      - '.github/workflows/publish_remote_api_image.yml'
 
   workflow_call: # enables workflow to be reused
     secrets:
@@ -18,6 +24,12 @@ on:
 permissions:
   id-token: write
   contents: read
+
+# Serialize image-publishing pipelines so a base-image cascade and a core/app
+# push can never publish out of order or race for the shared snapshot tags.
+concurrency:
+  group: publish-snapshot-images
+  cancel-in-progress: false
 
 jobs:
   build-and-publish-core-image:
@@ -32,8 +44,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Docker Image
+        # --pull forces Docker to fetch the latest faiss-base-snapshot base image
+        # from the registry instead of reusing a stale, locally-cached layer on
+        # the self-hosted runner. 
         run : |
-          docker build  -f ./remote_vector_index_builder/core/Dockerfile . -t opensearchstaging/remote-vector-index-builder:core-snapshot
+          docker build --pull -f ./remote_vector_index_builder/core/Dockerfile . -t opensearchstaging/remote-vector-index-builder:core-snapshot
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -119,20 +119,20 @@ docker build  -f ./base_image/build_scripts/Dockerfile . -t opensearchstaging/re
 
 ### Core Image
 The path [`/remote-vector-index-builder/core`](./remote_vector_index_builder/core/) contains the code for the `core` image.
-Run the below command to create the `core` image:
+Run the below command to create the `core` image. The `BASE_IMAGE_TAG` build arg must match the tag of the `faiss-base` image you built above (the Dockerfile defaults to `faiss-base-snapshot`):
 
 ```
-docker build  -f ./remote_vector_index_builder/core/Dockerfile . -t opensearchstaging/remote-vector-index-builder:core-latest
+docker build  -f ./remote_vector_index_builder/core/Dockerfile . --build-arg BASE_IMAGE_TAG=faiss-base-latest -t opensearchstaging/remote-vector-index-builder:core-latest
 ```
 
 The image can be built on any type of machine with `docker` installed
 
 ### API Image
 The path [`/remote-vector-index-builder/app`](./remote_vector_index_builder/app/) contains the code for the `api` image. 
-Run the below command to create `api` image. 
+Run the below command to create `api` image. The `CORE_IMAGE_TAG` build arg must match the tag of the `core` image you built above (the Dockerfile defaults to `core-snapshot`): 
 
 ```
-docker build  -f ./remote_vector_index_builder/app/Dockerfile . -t opensearchstaging/remote-vector-index-builder:api-latest
+docker build  -f ./remote_vector_index_builder/app/Dockerfile . --build-arg CORE_IMAGE_TAG=core-latest -t opensearchstaging/remote-vector-index-builder:api-latest
 ```
 
 The image can be built on any type of machine with `docker` installed

--- a/base_image/build_scripts/Dockerfile
+++ b/base_image/build_scripts/Dockerfile
@@ -10,8 +10,11 @@ RUN apt-get update && apt-get upgrade -y \
 RUN useradd -m appuser
 
 # Install miniconda
+# Pin the Miniconda installer version. The "latest" installer periodically ships
+# a newer conda that breaks this build (e.g. a PluginError during conda install),
+# Pinning keeps the base image build reproducible; bump this deliberately when upgrading conda.
 ENV CONDA_DIR /opt/conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py311_26.1.1-1-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda
 
 RUN chown -R appuser:appuser /opt


### PR DESCRIPTION
### Description
- Remove the standalone push trigger from publish_remote_api_image.yml; the api image is now built only via the base -> core -> api cascade.
- Add app/** to publish_remote_core_image.yml path triggers so app-only changes flow through the same ordered core -> api pipeline instead of a separate, unordered api workflow.
- Add --pull to every docker build so builds fetch the freshly-published parent image from the registry instead of a stale local cache on the self-hosted runner (root cause of #101).
- Add a shared 'publish-snapshot-images' concurrency group to the base and core workflows so a base cascade and a core/app push cannot publish the shared snapshot tags out of order.
- Pin the Miniconda installer in the faiss base image Dockerfile; the 'latest' installer began shipping a conda that fails the base image build.
- Fix DEVELOPER_GUIDE local build commands to pass matching BASE_IMAGE_TAG/ CORE_IMAGE_TAG build args.

### Issues Resolved
Resolves https://github.com/opensearch-project/remote-vector-index-builder/issues/101

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).