### PR TITLE
Revert "Add support for RTX Pro 4500 and RTX Pro 6000 (blackwell) (#147)"

### DIFF
--- a/base_image/build_scripts/Dockerfile
+++ b/base_image/build_scripts/Dockerfile
@@ -36,25 +36,21 @@ ENV PATH=$CONDA_DIR/bin:$PATH
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes
 
 #install some necessary dependencies
-RUN conda install -c conda-forge -y -q python=3.11 cmake=3.30.4 make=4.2 swig=4.0 "numpy<2" scipy=1.14 pytest=7.4 gflags=2.2 \
-    && conda clean --all --yes
+RUN conda install -c conda-forge -y -q python=3.11 cmake=3.30.4 make=4.2 swig=4.0 "numpy<2" scipy=1.14 pytest=7.4 gflags=2.2
 RUN cmake --version
 
 # set CUDA_ARCHS to use in cmake call in build script
-ENV CUDA_ARCHS="80-real;86-real;89-real;90-real;120-real;120-virtual"
+ENV CUDA_ARCHS "80;86-real"
 
 # install base packages for X86_64
-RUN conda install -y -q -c conda-forge gxx_linux-64=12.4 sysroot_linux-64=2.28 \
-    && conda clean --all --yes
+RUN conda install -y -q -c conda-forge gxx_linux-64=14.2 sysroot_linux-64=2.28
 
 # install all the dependencies we need for installing faiss
 # Ref: https://github.com/facebookresearch/faiss/blob/main/.github/actions/build_cmake/action.yml#L64
-RUN conda install -y -q libcuvs=26.06 cuda-nvcc cuda-version=12.9 gxx_linux-64=12.4 -c rapidsai -c rapidsai-nightly -c conda-forge \
-    && conda clean --all --yes
+RUN conda install -y -q libcuvs=26.06 cuda-nvcc 'cuda-version>=12.0,<=12.5' gxx_linux-64=12.4 -c rapidsai -c rapidsai-nightly -c conda-forge
 
 # Execute steps to build faiss
 # Ref: https://github.com/facebookresearch/faiss/blob/main/INSTALL.md#step-1-invoking-cmake
-RUN /tmp/build-faiss.sh \
-    && rm -rf /tmp/faiss /tmp/patches
+RUN /tmp/build-faiss.sh
 
 CMD ["sh", "-c", "nvidia-smi && sleep 36000"]

--- a/base_image/build_scripts/build-faiss.sh
+++ b/base_image/build_scripts/build-faiss.sh
@@ -19,12 +19,11 @@ cmake -B build \
     -DFAISS_OPT_LEVEL=generic \
     -DFAISS_ENABLE_C_API=OFF \
     -DFAISS_ENABLE_PYTHON=ON \
-    -DPYTHON_EXECUTABLE="${CONDA_DIR}/bin/python" \
+    -DPYTHON_EXECUTABLE=$CONDA/bin/python \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
     -DFAISS_ENABLE_CUVS=ON \
-    -DCMAKE_CUDA_COMPILER="${CONDA_DIR}/bin/nvcc" \
-    -DCUDAToolkit_ROOT="${CONDA_DIR}" \
+    -DCUDAToolkit_ROOT="/usr/local/cuda/lib64" \
     .
 
 # Step 2 : Invoke Make


### PR DESCRIPTION
### Description
Revert "Add support for RTX Pro 4500 and RTX Pro 6000 (blackwell) (#147)"

This reverts commit 5190f81601444501b99b99748b5c19a50b8065e8.

We are seeing failures on the KNN CI https://github.com/opensearch-project/k-NN/actions/runs/31839754921/job/94893919511?pr=3504 . 

Error:
```
 Caused by: java.lang.InterruptedException: Remote index build failed after 0 minutes. Faiss Index Build Service build_index workflow failed: Failed to create faiss GPU index: C++ exception transform: failed inside CUB: cudaErrorInvalidDeviceFunction: invalid device function
```
The CI will fail since the image which has been published as snapshot has the bug and current CI uses that image for running E2E tests

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).