### PR TITLE
Fixing the publish image workflows which are failing due to submodules fetch

### DIFF
--- a/.github/workflows/publish_faiss_base_image.yml
+++ b/.github/workflows/publish_faiss_base_image.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
             submodules: 'recursive'
+            fetch-depth: 0
             path: 'rvib'
 
       - name: Build Docker Image

--- a/.github/workflows/publish_remote_vector_version_images.yml
+++ b/.github/workflows/publish_remote_vector_version_images.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
             submodules: 'recursive'
+            fetch-depth: 0
 
       - name: Get Version
         id: get-version


### PR DESCRIPTION
### Description
Fixing the publish image workflows which are failing due to submodules fetch

Ref: https://github.com/opensearch-project/remote-vector-index-builder/actions/runs/32075553531/job/95529988584

### Issues Resolved
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).