### PR TITLE
Moving some maintainer to Emeritus, who are not actively working on the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-* @Rajrahane @navneet1v @yigithub @vamshin @jed326 @rchitale7 @owenhalpert @neetikasinghal
+* @navneet1v @yigithub @vamshin @rchitale7 @neetikasinghal

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,15 +11,15 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer               | GitHub ID                                                 | Affiliation |
 | ------------------------ | --------------------------------------------------------- | ----------- |
 | Navneet Verma            | [navneet1v](https://github.com/navneet1v  )               |    Amazon   |
-| Rajvaibhav Rahane        | [Rajrahane](https://github.com/Rajrahane)                 |    Amazon   |
 | Vamshi Vijay Nakkirtha   | [vamshin](https://github.com/vamshin)                     |    Amazon   |
 | Yigit Kiran              | [yigithub](https://github.com/yigithub)                   |    Amazon   |
-| Jay Deng                 | [jed326](https://github.com/jed326)                       |    Amazon   |
 | Rohan Chitale            | [rchitale7](https://github.com/rchitale7)                 |    Amazon   |
-| Owen Halpert             | [owenhalpert](https://github.com/owenhalpert)             |    Amazon   |
 | Neetika Singhal          | [neetikasinghal](https://github.com/neetikasinghal)       |    Amazon   |
 
 ## Emeritus
 
 | Maintainer               | GitHub ID                                                 | Affiliation |
 | ------------------------ | --------------------------------------------------------- | ----------- |
+| Rajvaibhav Rahane        | [Rajrahane](https://github.com/Rajrahane)                 |    Amazon   |
+| Jay Deng                 | [jed326](https://github.com/jed326)                       |    Amazon   |
+| Owen Halpert             | [owenhalpert](https://github.com/owenhalpert)             |    Amazon   |


### PR DESCRIPTION
### Description
Moving some maintainer to Emeritus, who are not actively working on the repo

### Issues Resolved
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).