### PR TITLE
Add RTX Pro 4500 / 6000 (blackwell) support

### DIFF
--- a/base_image/build_scripts/Dockerfile
+++ b/base_image/build_scripts/Dockerfile
@@ -36,21 +36,25 @@ ENV PATH=$CONDA_DIR/bin:$PATH
 ENV CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes
 
 #install some necessary dependencies
-RUN conda install -c conda-forge -y -q python=3.11 cmake=3.30.4 make=4.2 swig=4.0 "numpy<2" scipy=1.14 pytest=7.4 gflags=2.2
+RUN conda install -c conda-forge -y -q python=3.11 cmake=3.30.4 make=4.2 swig=4.0 "numpy<2" scipy=1.14 pytest=7.4 gflags=2.2 \
+    && conda clean --all --yes
 RUN cmake --version
 
 # set CUDA_ARCHS to use in cmake call in build script
-ENV CUDA_ARCHS "80;86-real"
+ENV CUDA_ARCHS="80;86-real;120-real"
 
 # install base packages for X86_64
-RUN conda install -y -q -c conda-forge gxx_linux-64=14.2 sysroot_linux-64=2.28
+RUN conda install -y -q -c conda-forge gxx_linux-64=14.2 sysroot_linux-64=2.28 \
+    && conda clean --all --yes
 
 # install all the dependencies we need for installing faiss
 # Ref: https://github.com/facebookresearch/faiss/blob/main/.github/actions/build_cmake/action.yml#L64
-RUN conda install -y -q libcuvs=26.06 cuda-nvcc 'cuda-version>=12.0,<=12.5' gxx_linux-64=12.4 -c rapidsai -c rapidsai-nightly -c conda-forge
+RUN conda install -y -q libcuvs=26.06 cuda-nvcc=12.9 cuda-version=12.9 gxx_linux-64=12.4 -c rapidsai -c rapidsai-nightly -c conda-forge \
+    && conda clean --all --yes
 
 # Execute steps to build faiss
 # Ref: https://github.com/facebookresearch/faiss/blob/main/INSTALL.md#step-1-invoking-cmake
-RUN /tmp/build-faiss.sh
+RUN /tmp/build-faiss.sh \
+    && rm -rf /tmp/faiss /tmp/patches
 
 CMD ["sh", "-c", "nvidia-smi && sleep 36000"]


### PR DESCRIPTION
### Description

This PR is a second pass at resolving https://github.com/opensearch-project/remote-vector-index-builder/issues/143. The first attempt https://github.com/opensearch-project/remote-vector-index-builder/pull/147 had to be reverted in https://github.com/opensearch-project/remote-vector-index-builder/pull/148 due to a regression on g6 (L4) instances. 

The reverted PR (https://github.com/opensearch-project/remote-vector-index-builder/pull/147) expanded the CUDA targets from `80;86-real` to `80-real;86-real;89-real;90-real;120-real;120-virtual` to provide explicit native images for additional GPU generations and make `compute_120` the forward-compatible PTX fallback.

The problem was the native `sm_89` Faiss artifact caused CAGRA `IVF_PQ` builds on g6/L4 instances to fail inside CUB with `cudaErrorInvalidDeviceFunction`.

This PR instead uses a more minimal diff from the existing `80;86-real` to `80;86-real;120-real`. This keeps the existing `80;86-real` configuration unchanged—including native `sm_80`, native `sm_86`, and `compute_80` PTX fallback—and adds only `120-real` for native g7/g7e Blackwell support.

CUDA is upgraded to 12.9 to compile `sm_120`.

For testing, I've been using the OpenSearch integration in our cuvs-bench benchmarking tool. With this setup I was able to reproduce the g6/L4 error from https://github.com/opensearch-project/remote-vector-index-builder/pull/147 and confirmed that this new PR is working as expected on g5 / g6 / g7 / g7e instances. Here are the logs I collected for runs on each of the instance types https://gist.github.com/jrbourbeau/e9f186ada558501376857a7909f3f2f2

cc @navneet1v @rchitale7 for viz 

### Issues Resolved

Closes https://github.com/opensearch-project/remote-vector-index-builder/issues/143

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).